### PR TITLE
Fix Instant conversion handling

### DIFF
--- a/core/src/main/java/org/projectnessie/cel/common/types/TimestampT.java
+++ b/core/src/main/java/org/projectnessie/cel/common/types/TimestampT.java
@@ -148,7 +148,7 @@ public final class TimestampT extends BaseVal implements Adder, Comparer, Receiv
   }
 
   public static TimestampT timestampOf(Instant t) {
-    return new TimestampT(ZonedDateTime.ofInstant(t, ZoneIdZ));
+    return timestampOf(t.toString());
   }
 
   public static TimestampT timestampOf(Timestamp t) {

--- a/core/src/test/java/org/projectnessie/cel/common/types/TimestampTest.java
+++ b/core/src/test/java/org/projectnessie/cel/common/types/TimestampTest.java
@@ -132,6 +132,20 @@ public class TimestampTest {
   }
 
   @Test
+  public void testInstantConversionResolution() {
+    String instantTime = "2021-06-18T09:39:05.070927Z";
+    String timestampTime = "google.protobuf.Timestamp{2021-06-18T09:39:05.000070927Z}";
+
+    // the nanosecond resolution for TimestampT should be the same when a string representation
+    // of an Instant is converted to TimestampT and if an Instant object is converted to TimestampT
+    TimestampT actual = timestampOf(instantTime);
+    TimestampT expected = timestampOf(Instant.parse(instantTime));
+    assertThat(actual).isEqualTo(expected);
+    assertThat(actual.toString()).isEqualTo(timestampTime);
+    assertThat(expected.toString()).isEqualTo(timestampTime);
+  }
+
+  @Test
   void timestampSubtract() {
     TimestampT ts = defaultTS();
     Val val = ts.subtract(durationOf(Duration.ofSeconds(3600, 1000)));


### PR DESCRIPTION
The problem was that `timestampOf(Instant)` would produce an Instant
without nanosecond precision. When comparing this Instant with an
Instant from `timestampOf(instant_string)`, comparisons would fail,
because the second one would have nanosecond precision.