### PR TITLE
Fix release-notes-step during release-workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
+          fetch-depth: '0'
           submodules: 'true'
 
       - name: Check commit status
@@ -130,11 +131,9 @@ jobs:
       - name: Prepare Release Notes
         id: prep_release
         run: |
-          git fetch --tags
-
           DIR=$(mktemp -d)
           NOTES_FILE=${DIR}/release-notes.md
-          LAST_TAG=$(git describe --tags --abbrev=0 HEAD^1)
+          LAST_TAG=$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))
           NUM_COMMITS=$(git log --format='format:%h' ${LAST_TAG}..HEAD | wc -l)
 
           git log --perl-regexp --author '^(?!.*dependabot|.*cel-java-release-workflow).*$' --format='format:* %s' ${LAST_TAG}..${GIT_TAG} | grep -v '^\* \[release\] .*$' > ${DIR}/release-log


### PR DESCRIPTION
In the GH WF step that creates the release-notes.md file, we need the commits
starting from the previous tag. However, the checkout-action provides "only" a
shallow clone (last commit), so there is no history.

The fix is to perform a "full" clone of the GH repo, which shouldn't be a big
deal, since the repo's history is linear.