### PR TITLE
Downgrade antlr to 4.8 to match Nessie 

### DIFF
--- a/generated-antlr/build.gradle.kts
+++ b/generated-antlr/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
     signing
 }
 
-val versionAntlr = "4.9.2"
+val versionAntlr = "4.8"
 
 dependencies {
     antlr("org.antlr:antlr4:$versionAntlr") // TODO remove from runtime-classpath *sigh*


### PR DESCRIPTION
Downgrade antlr version in CEL library  to match what we have in Nessie (4.8). In Nessie build logs I saw some warnings and errors related to the version mismatch, e.g:
```
2021-10-20T13:46:37.3349023Z [ERROR] ANTLR Tool version 4.9.2 used for code generation does not match the current runtime version 4.8
2021-10-20T13:46:37.3352032Z [ERROR] ANTLR Runtime version 4.9.2 used for parser compilation does not match the current runtime version 4.8
2021-10-20T13:46:37.3749587Z [ERROR] ANTLR Tool version 
2021-10-20T13:46:37.3754222Z [ERROR] 4.9.2
2021-10-20T13:46:37.3759485Z [ERROR]  used for code generation does not match the current runtime version 4.8
2021-10-20T13:46:37.3769785Z [ERROR] ANTLR Runtime version 4.9.2 used for parser compilation does not match the current runtime version 4.8
```

And it seems we can't upgrade antlr in Nessie since it needs to match antlr version in Spark as it is using 4.8 as well per [this PR](https://github.com/projectnessie/nessie/pull/1711)

cc @snazy 