### PR TITLE
Bump jwlawson/actions-setup-bazel from v1.6.1 to v1.7.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
           restore-keys: bazel-${{ matrix.java-version }}
 
       - name: Setup bazel
-        uses: jwlawson/actions-setup-bazel@v1.6.1
+        uses: jwlawson/actions-setup-bazel@v1.7.0
         with:
           bazel-version: '3.5.1'
 


### PR DESCRIPTION
Note: the tag v1.6.1 has been removed from that repo.