### PR TITLE
port strings extension library from cel-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,8 +231,6 @@ the necessary Gradle and bazel builds.
 * JSON extension ([see spec](https://github.com/google/cel-spec/blob/master/doc/langdef.md#json-data-conversion) and for example `nonFinite` in `com_github_golang_protobuf/jsonpb/decode.go`, around line 441)
 * Encoders extension ([like in Go](https://github.com/google/cel-go/blob/master/ext/encoders.go)),
   not difficult to port to Java, it's just work to be done at some point.
-* Strings extension ([like in Go](https://github.com/google/cel-go/blob/master/ext/strings.go)),
-  not difficult to port to Java, it's just work to be done at some point.
 
 ### Unsigned integer
 

--- a/core/src/main/java/org/projectnessie/cel/extension/Guards.java
+++ b/core/src/main/java/org/projectnessie/cel/extension/Guards.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2022 The Authors of CEL-Java
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.cel.extension;
+
+import java.util.function.BiFunction;
+import java.util.function.UnaryOperator;
+import org.projectnessie.cel.common.types.Err;
+import org.projectnessie.cel.common.types.IntT;
+import org.projectnessie.cel.common.types.ListT;
+import org.projectnessie.cel.common.types.StringT;
+import org.projectnessie.cel.interpreter.functions.BinaryOp;
+import org.projectnessie.cel.interpreter.functions.FunctionOp;
+import org.projectnessie.cel.interpreter.functions.UnaryOp;
+
+/** function invocation guards for common call signatures within extension functions. */
+public final class Guards {
+
+  private Guards() {}
+
+  public static BinaryOp callInStrIntOutStr(BiFunction<String, Integer, String> func) {
+    return (lhs, rhs) -> {
+      if (lhs.type() != StringT.StringType) {
+        return Err.maybeNoSuchOverloadErr(lhs);
+      }
+      if (rhs.type() != IntT.IntType) {
+        return Err.maybeNoSuchOverloadErr(rhs);
+      }
+      try {
+        return StringT.stringOf(func.apply(((String) lhs.value()), getIntValue((IntT) rhs)));
+      } catch (RuntimeException e) {
+        return Err.newErr(e, "%s", e.getMessage());
+      }
+    };
+  }
+
+  public static BinaryOp callInStrStrOutInt(BiFunction<String, String, Integer> func) {
+    return (lhs, rhs) -> {
+      if (lhs.type() != StringT.StringType) {
+        return Err.maybeNoSuchOverloadErr(lhs);
+      }
+      if (rhs.type() != StringT.StringType) {
+        return Err.maybeNoSuchOverloadErr(rhs);
+      }
+      try {
+        return IntT.intOf(func.apply(((String) lhs.value()), ((String) rhs.value())));
+      } catch (RuntimeException e) {
+        return Err.newErr(e, "%s", e.getMessage());
+      }
+    };
+  }
+
+  public static BinaryOp callInStrStrOutStrArr(BiFunction<String, String, String[]> func) {
+    return (lhs, rhs) -> {
+      if (lhs.type() != StringT.StringType) {
+        return Err.maybeNoSuchOverloadErr(lhs);
+      }
+      if (rhs.type() != StringT.StringType) {
+        return Err.maybeNoSuchOverloadErr(rhs);
+      }
+      try {
+        return ListT.newStringArrayList(func.apply(((String) lhs.value()), ((String) rhs.value())));
+      } catch (RuntimeException e) {
+        return Err.newErr(e, "%s", e.getMessage());
+      }
+    };
+  }
+
+  public static FunctionOp callInStrStrStrOutStr(TriFunction<String, String, String, String> func) {
+    return values -> {
+      if (values.length != 3) {
+        return Err.maybeNoSuchOverloadErr(null);
+      }
+      if (values[0].type() != StringT.StringType) {
+        return Err.maybeNoSuchOverloadErr(values[0]);
+      }
+      if (values[1].type() != StringT.StringType) {
+        return Err.maybeNoSuchOverloadErr(values[1]);
+      }
+      if (values[2].type() != StringT.StringType) {
+        return Err.maybeNoSuchOverloadErr(values[2]);
+      }
+      try {
+        return StringT.stringOf(
+            func.apply(
+                ((String) values[0].value()),
+                ((String) values[1].value()),
+                ((String) values[2].value())));
+      } catch (RuntimeException e) {
+        return Err.newErr(e, "%s", e.getMessage());
+      }
+    };
+  }
+
+  public static UnaryOp callInStrOutStr(UnaryOperator<String> func) {
+    return val -> {
+      if (val.type() != StringT.StringType) {
+        return Err.maybeNoSuchOverloadErr(val);
+      }
+      try {
+        return StringT.stringOf(func.apply(((String) val.value())));
+      } catch (RuntimeException e) {
+        return Err.newErr(e, "%s", e.getMessage());
+      }
+    };
+  }
+
+  private static int getIntValue(IntT value) {
+    Long longValue = (Long) value.value();
+    if (longValue > Integer.MAX_VALUE || (longValue < Integer.MIN_VALUE)) {
+      throw new RuntimeException(String.format("Integer %d value overflow", longValue));
+    }
+    return longValue.intValue();
+  }
+}

--- a/core/src/main/java/org/projectnessie/cel/extension/QuadFunction.java
+++ b/core/src/main/java/org/projectnessie/cel/extension/QuadFunction.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2022 The Authors of CEL-Java
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.cel.extension;
+
+@FunctionalInterface
+public interface QuadFunction<A, B, C, D, R> {
+  R apply(A a, B b, C c, D d);
+}

--- a/core/src/main/java/org/projectnessie/cel/extension/StringsLib.java
+++ b/core/src/main/java/org/projectnessie/cel/extension/StringsLib.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright (C) 2022 The Authors of CEL-Java
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.cel.extension;
+
+import java.util.*;
+import java.util.regex.Pattern;
+import org.projectnessie.cel.EnvOption;
+import org.projectnessie.cel.Library;
+import org.projectnessie.cel.ProgramOption;
+import org.projectnessie.cel.checker.Decls;
+import org.projectnessie.cel.interpreter.functions.Overload;
+
+/**
+ * StringsLib provides a {@link org.projectnessie.cel.EnvOption} to configure extended functions for
+ * string manipulation. As a general note, all indices are zero-based. The implementation is ported
+ * from <a href=https://github.com/google/cel-go/blob/master/ext/strings.go>cel-go</a>.
+ *
+ * <p>Note: Currently the overloading isn't supported.
+ *
+ * <h3>CharAt</h3>
+ *
+ * <p>Returns the character at the given position. If the position is negative, or greater than the
+ * length of the string, the function will produce an error:
+ *
+ * <pre>    {@code <string>.charAt(<int>) -> <string>}</pre>
+ *
+ * <h4>Examples:</h4>
+ *
+ * <pre>    {@code 'hello'.charAt(4) // return 'o'}</pre>
+ *
+ * <pre>    {@code 'hello'.charAt(5) // return ''}</pre>
+ *
+ * <pre>    {@code 'hello'.charAt(-1) // error}</pre>
+ *
+ * <h3>IndexOf</h3>
+ *
+ * <p>Returns the integer index of the first occurrence of the search string. If the search string
+ * is not found the function returns -1.
+ *
+ * <pre>    {@code <string>.indexOf(<string>) -> <int>}</pre>
+ *
+ * <h4>Examples:</h4>
+ *
+ * <pre>    {@code 'hello mellow'.indexOf('') // returns 0}</pre>
+ *
+ * <pre>    {@code 'hello mellow'.indexOf('ello') // returns 1}</pre>
+ *
+ * <pre>    {@code 'hello mellow'.indexOf('jello') // returns -1}</pre>
+ *
+ * <h3>LastIndexOf</h3>
+ *
+ * <p>Returns the integer index at the start of the last occurrence of the search string. If the
+ * search string is not found the function returns -1.
+ *
+ * <pre>    {@code <string>.lastIndexOf(<string>) -> <int>}</pre>
+ *
+ * <h4>Examples:</h4>
+ *
+ * <pre>    {@code 'hello mellow'.lastIndexOf('') // returns 12}</pre>
+ *
+ * <pre>    {@code 'hello mellow'.lastIndexOf('ello') // returns 7}</pre>
+ *
+ * <pre>    {@code 'hello mellow'.lastIndexOf('jello') // returns -1}</pre>
+ *
+ * <h3>LowerAscii</h4>
+ *
+ * <p>Returns a new string where all ASCII characters are lower-cased.
+ *
+ * <p>This function does not perform Unicode case-mapping for characters outside the ASCII range.
+ *
+ * <pre>    {@code <string>.lowerAscii() -> <string>}</pre>
+ *
+ * <h4>Examples:</h4>
+ *
+ * <pre>    {@code 'TacoCat'.lowerAscii() // returns 'tacocat'}</pre>
+ *
+ * <pre>    {@code 'TacoCÆt Xii'.lowerAscii() // returns 'tacocÆt xii'}</pre>
+ *
+ * <h3>Replace</h3>
+ *
+ * <p>Returns a new string based on the target, which replaces the occurrences of a search string
+ * with a replacement string if present.
+ *
+ * <pre>    {@code <string>.replace(<string>, <string>) -> <string>}</pre>
+ *
+ * <h4>Examples:</h4>
+ *
+ * <pre>    {@code 'hello hello'.replace('he', 'we') // returns 'wello wello'}</pre>
+ *
+ * <h3>Split</h3>
+ *
+ * <p>Returns a list of strings split from the input by the given separator.
+ *
+ * <pre>    {@code <string>.split(<string>) -> <list<string>>}</pre>
+ *
+ * <h4>Examples:</h4>
+ *
+ * <pre>    {@code hello hello hello'.split(' ')     // returns ['hello', 'hello', 'hello']}</pre>
+ *
+ * <h3>Substring</h3>
+ *
+ * <p>Returns the substring given a numeric range corresponding to character positions.
+ *
+ * <p>Character offsets are 0-based with an inclusive start range.
+ *
+ * <pre>    {@code <string>.substring(<int>) -> <string>}</pre>
+ *
+ * <h4>Examples:</h4>
+ *
+ * <pre>    {@code 'tacocat'.substring(4) // returns 'cat'}</pre>
+ *
+ * <pre>    {@code 'tacocat'.substring(-1) // error} </pre>
+ *
+ * <h3>Trim</h3>
+ *
+ * <p>Returns a new string which removes the leading and trailing whitespace in the target string.
+ * The trim function uses the Unicode definition of whitespace which does not include the zero-width
+ * spaces. See: <a href="https://en.wikipedia.org/wiki/Whitespace_character#Unicode">Unicode</a>
+ *
+ * <pre>    {@code <string>.trim() -> <string>}</pre>
+ *
+ * <h4>Examples:</h4>
+ *
+ * <pre>    {@code ' \ttrim\n '.trim() // returns 'trim'}</pre>
+ *
+ * <h3>UpperAscii</h3>
+ *
+ * <p>Returns a new string where all ASCII characters are upper-cased.
+ *
+ * <p>This function does not perform Unicode case-mapping for characters outside the ASCII range.
+ *
+ * <pre>    {@code <string>.upperAscii() -> <string>}</pre>
+ *
+ * <h4>Examples:</h4>
+ *
+ * <pre>    {@code 'TacoCat'.upperAscii() // returns 'TACOCAT'}</pre>
+ *
+ * <pre>    {@code 'TacoCÆt Xii'.upperAscii() // returns 'TACOCÆT XII'}</pre>
+ */
+public class StringsLib implements Library {
+
+  private static final String CHAR_AT = "charAt";
+  private static final String INDEX_OF = "indexOf";
+  private static final String LAST_INDEX_OF = "lastIndexOf";
+  private static final String LOWER_ASCII = "lowerAscii";
+  private static final String REPLACE = "replace";
+  private static final String SPLIT = "split";
+  private static final String SUBSTR = "substring";
+  private static final String TRIM_SPACE = "trim";
+  private static final String UPPER_ASCII = "upperAscii";
+
+  // whitespace characters definition from
+  // https://en.wikipedia.org/wiki/Whitespace_character#Unicode
+  private static final Set<Character> UNICODE_WHITE_SPACES =
+      new HashSet<>(
+          Arrays.asList(
+              (char) 0x0009,
+              (char) 0x000A,
+              (char) 0x000B,
+              (char) 0x000C,
+              (char) 0x000D,
+              (char) 0x0020,
+              (char) 0x0085,
+              (char) 0x00A0,
+              (char) 0x1680,
+              (char) 0x2000,
+              (char) 0x2001,
+              (char) 0x2002,
+              (char) 0x2003,
+              (char) 0x2004,
+              (char) 0x2005,
+              (char) 0x2006,
+              (char) 0x2007,
+              (char) 0x2008,
+              (char) 0x2009,
+              (char) 0x200A,
+              (char) 0x2028,
+              (char) 0x2029,
+              (char) 0x202F,
+              (char) 0x205F,
+              (char) 0x3000));
+
+  public static EnvOption strings() {
+    return Library.Lib(new StringsLib());
+  }
+
+  @Override
+  public List<EnvOption> getCompileOptions() {
+    List<EnvOption> list = new ArrayList<>();
+    EnvOption option =
+        EnvOption.declarations(
+            Decls.newFunction(
+                CHAR_AT,
+                Decls.newInstanceOverload(
+                    "string_char_at_int", Arrays.asList(Decls.String, Decls.Int), Decls.String)),
+            Decls.newFunction(
+                INDEX_OF,
+                Decls.newInstanceOverload(
+                    "string_index_of_string",
+                    Arrays.asList(Decls.String, Decls.String),
+                    Decls.Int)),
+            Decls.newFunction(
+                LAST_INDEX_OF,
+                Decls.newInstanceOverload(
+                    "string_last_index_of_string",
+                    Arrays.asList(Decls.String, Decls.String),
+                    Decls.Int)),
+            Decls.newFunction(
+                LOWER_ASCII,
+                Decls.newInstanceOverload(
+                    "string_lower_ascii", Arrays.asList(Decls.String), Decls.String)),
+            Decls.newFunction(
+                REPLACE,
+                Decls.newInstanceOverload(
+                    "string_replace_string_string",
+                    Arrays.asList(Decls.String, Decls.String, Decls.String),
+                    Decls.String)),
+            Decls.newFunction(
+                SPLIT,
+                Decls.newInstanceOverload(
+                    "string_split_string", Arrays.asList(Decls.String, Decls.String), Decls.Dyn)),
+            Decls.newFunction(
+                SUBSTR,
+                Decls.newInstanceOverload(
+                    "string_substring_int", Arrays.asList(Decls.String, Decls.Int), Decls.String)),
+            Decls.newFunction(
+                TRIM_SPACE,
+                Decls.newInstanceOverload(
+                    "string_trim", Arrays.asList(Decls.String), Decls.String)),
+            Decls.newFunction(
+                UPPER_ASCII,
+                Decls.newInstanceOverload(
+                    "string_upper_ascii", Arrays.asList(Decls.String), Decls.String)));
+    list.add(option);
+    return list;
+  }
+
+  @Override
+  public List<ProgramOption> getProgramOptions() {
+    List<ProgramOption> list = new ArrayList<>();
+    ProgramOption functions =
+        ProgramOption.functions(
+            Overload.binary(CHAR_AT, Guards.callInStrIntOutStr(StringsLib::charAt)),
+            Overload.binary(INDEX_OF, Guards.callInStrStrOutInt(StringsLib::indexOf)),
+            Overload.binary(LAST_INDEX_OF, Guards.callInStrStrOutInt(StringsLib::lastIndexOf)),
+            Overload.unary(LOWER_ASCII, Guards.callInStrOutStr(StringsLib::lowerASCII)),
+            Overload.function(REPLACE, Guards.callInStrStrStrOutStr(StringsLib::replace)),
+            Overload.binary(SPLIT, Guards.callInStrStrOutStrArr(StringsLib::split)),
+            Overload.binary(SUBSTR, Guards.callInStrIntOutStr(StringsLib::substr)),
+            Overload.unary(TRIM_SPACE, Guards.callInStrOutStr(StringsLib::trimSpace)),
+            Overload.unary(UPPER_ASCII, Guards.callInStrOutStr(StringsLib::upperASCII)));
+    list.add(functions);
+    return list;
+  }
+
+  static String charAt(String str, int index) {
+    if (str.length() == index) {
+      return "";
+    }
+    return String.valueOf(str.charAt(index));
+  }
+
+  static int indexOf(String str, String substr) {
+    return str.indexOf(substr);
+  }
+
+  static int lastIndexOf(String str, String substr) {
+    return str.lastIndexOf(substr);
+  }
+
+  static String lowerASCII(String str) {
+    StringBuilder stringBuilder = new StringBuilder();
+    for (char c : str.toCharArray()) {
+      if (c >= 'A' && c <= 'Z') {
+        stringBuilder.append(Character.toLowerCase(c));
+      } else {
+        stringBuilder.append(c);
+      }
+    }
+    return stringBuilder.toString();
+  }
+
+  static String replace(String str, String old, String replacement) {
+    return str.replace(old, replacement);
+  }
+
+  static String[] split(String str, String separator) {
+    return str.split(Pattern.quote(separator));
+  }
+
+  static String substr(String str, int start) {
+    return str.substring(start);
+  }
+
+  static String trimSpace(String str) {
+    char[] chars = str.toCharArray();
+    int start = 0;
+    int end = str.length() - 1;
+    while (start < str.length()) {
+      if (!isWhiteSpace(chars[start])) {
+        break;
+      }
+      start++;
+    }
+    while (end > start) {
+      if (!isWhiteSpace(chars[end])) {
+        break;
+      }
+      end--;
+    }
+
+    return str.substring(start, end + 1);
+  }
+
+  /**
+   * test if given character is whitespace as defined by <a
+   * href="https://en.wikipedia.org/wiki/Whitespace_character#Unicode">Unicode</a>
+   *
+   * <p>Java functions like {@link java.lang.Character#isWhitespace(char)} or {@link
+   * java.lang.Character#isWhitespace(int)} use different whitespace definition hence they can't be
+   * used here.
+   *
+   * @param ch the character to be tested
+   * @return true if the character is a Unicode whitespace character; false otherwise.
+   */
+  private static boolean isWhiteSpace(char ch) {
+    // cel-go 'trim' extension function uses strings.TrimSpace()
+    return UNICODE_WHITE_SPACES.contains(ch);
+  }
+
+  static String upperASCII(String str) {
+    StringBuilder stringBuilder = new StringBuilder();
+    for (char c : str.toCharArray()) {
+      if (c >= 'a' && c <= 'z') {
+        stringBuilder.append(Character.toUpperCase(c));
+      } else {
+        stringBuilder.append(c);
+      }
+    }
+    return stringBuilder.toString();
+  }
+}

--- a/core/src/main/java/org/projectnessie/cel/extension/TriFunction.java
+++ b/core/src/main/java/org/projectnessie/cel/extension/TriFunction.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2022 The Authors of CEL-Java
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.cel.extension;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+@FunctionalInterface
+interface TriFunction<A, B, C, R> {
+
+  R apply(A a, B b, C c);
+
+  default <V> TriFunction<A, B, C, V> andThen(Function<? super R, ? extends V> after) {
+    Objects.requireNonNull(after);
+    return (A a, B b, C c) -> after.apply(apply(a, b, c));
+  }
+}

--- a/core/src/test/java/org/projectnessie/cel/extension/StringsTest.java
+++ b/core/src/test/java/org/projectnessie/cel/extension/StringsTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright (C) 2022 The Authors of CEL-Java
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.cel.extension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.*;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.projectnessie.cel.Env;
+import org.projectnessie.cel.Library;
+import org.projectnessie.cel.Program;
+import org.projectnessie.cel.common.types.BoolT;
+import org.projectnessie.cel.common.types.Err;
+import org.projectnessie.cel.common.types.pb.ProtoTypeRegistry;
+import org.projectnessie.cel.common.types.ref.Val;
+
+public class StringsTest {
+
+  @ParameterizedTest
+  @MethodSource("testCases")
+  public void testStrings(TestData testData) {
+    testExpression(testData);
+  }
+
+  static Stream<TestData> testCases() {
+    return Stream.of(
+        new TestData("'tacocat'.charAt(3) == 'o'"),
+        new TestData("'tacocat'.charAt(7) == ''"),
+        new TestData("'©αT'.charAt(0) == '©' && '©αT'.charAt(1) == 'α' && '©αT'.charAt(2) == 'T'"),
+        new TestData("'tacocat'.charAt(30) == ''", "String index out of range: 30"),
+        new TestData("'tacocat'.indexOf('') == 0"),
+        new TestData("'tacocat'.indexOf('ac') == 1"),
+        new TestData("'tacocat'.indexOf('none') == -1"),
+        /*
+            new TestData("'tacocat'.indexOf('', 3) == 3"),
+            new TestData("'tacocat'.indexOf('a', 3) == 5"),
+            new TestData("'tacocat'.indexOf('at', 3) == 5"),
+        */
+        new TestData("'ta©o©αT'.indexOf('©') == 2"),
+        /*
+            new TestData("'ta©o©αT'.indexOf('©', 3) == 4"),
+            new TestData("'ta©o©αT'.indexOf('©αT', 3) == 4"),
+            new TestData("'ta©o©αT'.indexOf('©α', 5) == -1"),
+        */
+        new TestData("'tacocat'.lastIndexOf('') == 7"),
+        new TestData("'tacocat'.lastIndexOf('at') == 5"),
+        new TestData("'tacocat'.lastIndexOf('none') == -1"),
+        /*
+            new TestData("'tacocat'.lastIndexOf('', 3) == 3"),
+            new TestData("'tacocat'.lastIndexOf('a', 3) == 1"),
+        */
+        new TestData("'ta©o©αT'.lastIndexOf('©') == 4"),
+        /*
+            new TestData("'ta©o©αT'.lastIndexOf('©', 3) == 2"),
+            new TestData("'ta©o©αT'.lastIndexOf('©α', 4) == 4"),
+        */
+        new TestData("'TacoCat'.lowerAscii() == 'tacocat'"),
+        new TestData("'TacoCÆt Xii'.lowerAscii() == 'tacocÆt xii'"),
+        new TestData("'hello hello'.replace('he', 'we') == 'wello wello'"),
+        new TestData("\"12 days 12 hours\".replace(\"{0}\", \"2\") == \"12 days 12 hours\""),
+        new TestData("\"{0} days {0} hours\".replace(\"{0}\", \"2\") == \"2 days 2 hours\""),
+        /*
+            new TestData("\"{0} days {0} hours\".replace(\"{0}\", \"2\", 1).replace(\"{0}\", \"23\") == \"2 days 23 hours\""),
+        */
+        new TestData("\"1 ©αT taco\".replace(\"αT\", \"o©α\") == \"1 ©o©α taco\""),
+        new TestData("'hello hello hello'.split(' ') == ['hello', 'hello', 'hello']"),
+        new TestData("\"hello world\".split(\" \") == [\"hello\", \"world\"]"),
+        /*
+            new TestData("\"hello world events!\".split(\" \", 0) == []"),
+            new TestData("\"hello world events!\".split(\" \", 1) == [\"hello world events!\"]"),
+            new TestData("\"o©o©o©o\".split(\"©\", -1) == [\"o\", \"o\", \"o\", \"o\"]"),
+        */
+        new TestData("\"tacocat\".substring(4) == \"cat\""),
+        new TestData("\"tacocat\".substring(7) == \"\""),
+        /*
+            new TestData("\"tacocat\".substring(0, 4) == \"taco\""),
+            new TestData("\"tacocat\".substring(4, 4) == \"\""),
+            new TestData("'ta©o©αT'.substring(2, 6) == \"©o©α\""),
+            new TestData("'ta©o©αT'.substring(7, 7) == \"\""),
+        */
+        new TestData("'TacoCat'.upperAscii() == 'TACOCAT'"),
+        new TestData("'TacoCÆt Xii'.upperAscii() == 'TACOCÆT XII'"),
+        new TestData("\" \\f\\n\\r\\t\\vtext  \".trim() == \"text\""),
+        new TestData("\"\u0085\u00a0\u1680text\".trim() == \"text\""),
+        new TestData(
+            "\"text\u2000\u2001\u2002\u2003\u2004\u2004\u2006\u2007\u2008\u2009\".trim() == \"text\""),
+        new TestData("\"\u200atext\u2028\u2029\u202F\u205F\u3000\".trim() == \"text\""),
+        // Trim test with whitespace-like characters not included.
+        new TestData(
+            "\"\u180etext\u200b\u200c\u200d\u2060\ufeff\".trim() == \"\u180etext\u200b\u200c\u200d\u2060\ufeff\""),
+
+        // Error test cases based on checked expression usage.
+        /*
+                new TestData("'tacocat'.indexOf('a', 30) == -1", "String index out of range: 30"),
+                new TestData("'tacocat'.lastIndexOf('a', -1) == -1", "String index out of range: -1"),
+                new TestData("'tacocat'.lastIndexOf('a', 30) == -1", "String index out of range: 30"),
+        */
+
+        new TestData(
+            "\"tacocat\".substring(40) == \"cat\"",
+            "String index out of range: -33",
+            false,
+            new TreeMap<Integer, String>(Collections.reverseOrder()) {
+              {
+                put(14, "begin 40, end 7, length 7");
+              }
+            }),
+        new TestData(
+            "\"tacocat\".substring(-1) == \"cat\"",
+            "String index out of range: -1",
+            false,
+            new TreeMap<Integer, String>(Collections.reverseOrder()) {
+              {
+                put(14, "begin -1, end 7, length 7");
+              }
+            }),
+        /*
+                new TestData("\"tacocat\".substring(1, 50) == \"cat\"", "String index out of range: 50"),
+                new TestData("\"tacocat\".substring(49, 50) == \"cat\"", "String index out of range: 49"),
+                new TestData(
+                    "\"tacocat\".substring(4, 3) == \"\"", "invalid substring range. start: 4, end: 3"),
+        */
+
+        // Valid parse-only expressions which should generate runtime errors.
+        new TestData("42.charAt(2) == \"\"", "no matching overload", true),
+        new TestData("'hello'.charAt(true) == \"\"", "no matching overload", true),
+        new TestData("24.indexOf('2') == 0", "no matching overload", true),
+        new TestData("'hello'.indexOf(true) == 1", "no matching overload", true),
+        new TestData("42.indexOf('4', 0) == 0", "no matching overload", true),
+        new TestData("'42'.indexOf(4, 0) == 0", "no matching overload", true),
+        new TestData("'42'.indexOf('4', '0') == 0", "no matching overload", true),
+        new TestData("'42'.indexOf('4', 0, 1) == 0", "no matching overload", true),
+        new TestData("24.lastIndexOf('2') == 0", "no matching overload", true),
+        new TestData("'hello'.lastIndexOf(true) == 1", "no matching overload", true),
+        new TestData("42.lastIndexOf('4', 0) == 0", "no matching overload", true),
+        new TestData("'42'.lastIndexOf(4, 0) == 0", "no matching overload", true),
+        new TestData("'42'.lastIndexOf('4', '0') == 0", "no matching overload", true),
+        new TestData("'42'.lastIndexOf('4', 0, 1) == 0", "no matching overload", true),
+        new TestData("42.replace(2, 1) == \"41\"", "no matching overload", true),
+        new TestData("\"42\".replace(2, 1) == \"41\"", "no matching overload", true),
+        new TestData("\"42\".replace(\"2\", 1) == \"41\"", "no matching overload", true),
+        new TestData("42.replace(\"2\", \"1\", 1) == \"41\"", "no matching overload", true),
+        new TestData("\"42\".replace(2, \"1\", 1) == \"41\"", "no matching overload", true),
+        new TestData("\"42\".replace(\"2\", 1, 1) == \"41\"", "no matching overload", true),
+        new TestData("\"42\".replace(\"2\", \"1\", \"1\") == \"41\"", "no matching overload", true),
+        new TestData(
+            "\"42\".replace(\"2\", \"1\", 1, false) == \"41\"", "no matching overload", true),
+        new TestData("42.split(\"2\") == [\"4\"]", "no matching overload", true),
+        new TestData("42.split(\"\") == [\"4\", \"2\"]", "no matching overload", true),
+        new TestData("\"42\".split(2) == [\"4\"]", "no matching overload", true),
+        new TestData("42.split(\"2\", \"1\") == [\"4\"]", "no matching overload", true),
+        new TestData("\"42\".split(2, 1) == [\"4\"]", "no matching overload", true),
+        new TestData("\"42\".split(\"2\", \"1\") == [\"4\"]", "no matching overload", true),
+        new TestData("\"42\".split(\"2\", 1, 1) == [\"4\"]", "no matching overload", true),
+        new TestData("'hello'.substring(1, 2, 3) == \"\"", "no matching overload", true),
+        new TestData("30.substring(true, 3) == \"\"", "no matching overload", true),
+        new TestData("\"tacocat\".substring(true, 3) == \"\"", "no matching overload", true),
+        new TestData("\"tacocat\".substring(0, false) == \"\"", "no matching overload", true));
+  }
+
+  private static void testExpression(TestData testData) {
+    Env env =
+        Env.newCustomEnv(
+            ProtoTypeRegistry.newRegistry(), Arrays.asList(Library.StdLib(), StringsLib.strings()));
+
+    Env.AstIssuesTuple astIssue = env.parse(testData.expression);
+    assertThat(astIssue.hasIssues()).isFalse();
+
+    Env.AstIssuesTuple checked = env.check(astIssue.getAst());
+    if (testData.isParseOnly()) {
+      assertThat(checked.hasIssues()).isTrue();
+      assertThat(checked.getIssues().toString()).contains(testData.getErr());
+      return;
+    } else {
+      assertThat(checked.hasIssues()).isFalse();
+    }
+
+    Program program = env.program(astIssue.getAst());
+    Program.EvalResult result = program.eval(new HashMap<>());
+
+    if (testData.getErr() != null) {
+      assertThat(result.getVal() instanceof Err).isTrue();
+      assertThat(result.getVal()).extracting(Val::toString).isEqualTo(testData.getErr());
+    } else {
+      assertThat(result.getVal()).isEqualTo(BoolT.True);
+    }
+  }
+
+  private static final class TestData {
+    private final String expression;
+    private final String err;
+    private final boolean parseOnly;
+    private final Map<Integer, String> versionedErrs;
+
+    TestData(String expression) {
+      this(expression, null);
+    }
+
+    TestData(String expression, String err) {
+      this(expression, err, false);
+    }
+
+    TestData(String expression, String err, boolean parseOnly) {
+      this(expression, err, parseOnly, null);
+    }
+
+    TestData(String expression, String err, boolean parseOnly, Map<Integer, String> versionedErrs) {
+      this.expression = expression;
+      this.err = err;
+      this.parseOnly = parseOnly;
+      this.versionedErrs = versionedErrs;
+    }
+
+    public String getExpression() {
+      return expression;
+    }
+
+    public String getErr() {
+      // java 14 has different exception messages. The versionedErrs allow the test case to check on
+      // different error messages based on Java version.
+      // The `versionedErrs` has java version as key and sorted in descending order. It will allow
+      // multiple values based on java version. So far it is limited to major versions only.
+      // Since java9, Runtime.version() function can be used to get java version.
+      // For java8 support, "java.version" system property is still used to get the java version
+      String version = System.getProperty("java.version");
+      String[] versions = version.split("\\.");
+      int major = Integer.parseInt(versions[0]);
+      if (this.versionedErrs != null) {
+        for (Map.Entry<Integer, String> entry : this.versionedErrs.entrySet()) {
+          if (major >= entry.getKey()) {
+            return entry.getValue();
+          }
+        }
+      }
+      return err;
+    }
+
+    public boolean isParseOnly() {
+      return parseOnly;
+    }
+
+    @Override
+    public String toString() {
+      return expression;
+    }
+  }
+}


### PR DESCRIPTION
### issue #103: port strings extension library from [cel-go](https://github.com/google/cel-go/blob/master/ext/strings.go) ### 

- all strings extension functions are covered
- because of limit on [Overload](https://github.com/projectnessie/cel-java/blob/main/core/src/main/java/org/projectnessie/cel/interpreter/functions/Overload.java)'s constructor, multiple overrides for same function are not supported. That will be covered in separated issue/PR
-- e.g. `indexOf` function only accepts one parameter
-- similar to `lastIndexOf`, `replace`, `split`, `substring`
- Gaurds.java is similar to [guards.go](https://github.com/google/cel-go/blob/master/ext/guards.go)
- `TriFunction` and `QuadFunction` interfaces are introduced as JDK doesn't provide [BIFunction]([BiFunction (Java Platform SE 8 ) - Oracle Help Centerhttps://docs.oracle.com › api › java › util › function › B...](https://docs.oracle.com/javase/8/docs/api/java/util/function/BiFunction.html)) and [UnaryOperator](https://docs.oracle.com/javase/8/docs/api/java/util/function/UnaryOperator.html)
