### PR TITLE
Turn off codecov github annotations

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2022 The Authors of CEL-Java
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# https://docs.codecov.com/docs/codecovyml-reference
+
+github_checks:
+  annotations: false


### PR DESCRIPTION
See also https://docs.codecov.com/docs/github-checks

It can be argued that having theses inline annotations is too noisy for reviewers when you already have an automated codecov comment outlining the coverage numbers for the codebase as well as on the diff of the PR.
If you need more line-by-line details you can simply follow the link from the comment to the codecov report.