### PR TITLE
Fix build warning

### DIFF
--- a/build-tools/src/main/kotlin/org/projectnessie/cel/tools/plugins/ReflectionConfigPlugin.kt
+++ b/build-tools/src/main/kotlin/org/projectnessie/cel/tools/plugins/ReflectionConfigPlugin.kt
@@ -63,7 +63,9 @@ class ReflectionConfigPlugin : Plugin<Project> {
         tasks.named(sourcesJarTaskName) {
           dependsOn(genRefCfg)
         }
-      } catch (ignore: UnknownTaskException) { null }
+      } catch (ignore: UnknownTaskException) {
+        // ignore
+      }
     }
   }
 }


### PR DESCRIPTION
`ReflectionConfigPlugin.kt: (66, 48): The expression is unused`