### PR TITLE
Let dependabot check all modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,35 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+- package-ecosystem: gradle
+  directory: "/build-tools/"
+  schedule:
+    interval: daily
+- package-ecosystem: gradle
+  directory: "/conformance/"
+  schedule:
+    interval: daily
+- package-ecosystem: gradle
+  directory: "/core/"
+  schedule:
+    interval: daily
+- package-ecosystem: gradle
+  directory: "/jackson/"
+  schedule:
+    interval: daily
+- package-ecosystem: gradle
+  directory: "/jacoco/"
+  schedule:
+    interval: daily
+- package-ecosystem: gradle
+  directory: "/generated-antlr/"
+  schedule:
+    interval: daily
+- package-ecosystem: gradle
+  directory: "/generated-pb/"
+  schedule:
+    interval: daily
+- package-ecosystem: gradle
+  directory: "/tools/"
+  schedule:
+    interval: daily


### PR DESCRIPTION
Dependabot only checks the build scripts of the configured directory,
but not the ones in submodules.