### PR TITLE
add strings extension functions with multiple overloads

### DIFF
--- a/core/src/main/java/org/projectnessie/cel/extension/Guards.java
+++ b/core/src/main/java/org/projectnessie/cel/extension/Guards.java
@@ -32,12 +32,6 @@ public final class Guards {
 
   public static BinaryOp callInStrIntOutStr(BiFunction<String, Integer, String> func) {
     return (lhs, rhs) -> {
-      if (lhs.type() != StringT.StringType) {
-        return Err.maybeNoSuchOverloadErr(lhs);
-      }
-      if (rhs.type() != IntT.IntType) {
-        return Err.maybeNoSuchOverloadErr(rhs);
-      }
       try {
         return StringT.stringOf(func.apply(((String) lhs.value()), getIntValue((IntT) rhs)));
       } catch (RuntimeException e) {
@@ -46,14 +40,23 @@ public final class Guards {
     };
   }
 
+  public static FunctionOp callInStrIntIntOutStr(
+      TriFunction<String, Integer, Integer, String> func) {
+    return values -> {
+      try {
+        return StringT.stringOf(
+            func.apply(
+                ((String) values[0].value()),
+                (getIntValue((IntT) values[1])),
+                (getIntValue((IntT) values[2]))));
+      } catch (RuntimeException e) {
+        return Err.newErr(e, "%s", e.getMessage());
+      }
+    };
+  }
+
   public static BinaryOp callInStrStrOutInt(BiFunction<String, String, Integer> func) {
     return (lhs, rhs) -> {
-      if (lhs.type() != StringT.StringType) {
-        return Err.maybeNoSuchOverloadErr(lhs);
-      }
-      if (rhs.type() != StringT.StringType) {
-        return Err.maybeNoSuchOverloadErr(rhs);
-      }
       try {
         return IntT.intOf(func.apply(((String) lhs.value()), ((String) rhs.value())));
       } catch (RuntimeException e) {
@@ -62,14 +65,23 @@ public final class Guards {
     };
   }
 
+  public static FunctionOp callInStrStrIntOutInt(
+      TriFunction<String, String, Integer, Integer> func) {
+    return values -> {
+      try {
+        return IntT.intOf(
+            func.apply(
+                ((String) values[0].value()),
+                ((String) values[1].value()),
+                (getIntValue((IntT) values[2]))));
+      } catch (RuntimeException e) {
+        return Err.newErr(e, "%s", e.getMessage());
+      }
+    };
+  }
+
   public static BinaryOp callInStrStrOutStrArr(BiFunction<String, String, String[]> func) {
     return (lhs, rhs) -> {
-      if (lhs.type() != StringT.StringType) {
-        return Err.maybeNoSuchOverloadErr(lhs);
-      }
-      if (rhs.type() != StringT.StringType) {
-        return Err.maybeNoSuchOverloadErr(rhs);
-      }
       try {
         return ListT.newStringArrayList(func.apply(((String) lhs.value()), ((String) rhs.value())));
       } catch (RuntimeException e) {
@@ -78,20 +90,23 @@ public final class Guards {
     };
   }
 
+  public static FunctionOp callInStrStrIntOutStrArr(
+      TriFunction<String, String, Integer, String[]> func) {
+    return values -> {
+      try {
+        return ListT.newStringArrayList(
+            func.apply(
+                ((String) values[0].value()),
+                ((String) values[1].value()),
+                getIntValue((IntT) values[2])));
+      } catch (RuntimeException e) {
+        return Err.newErr(e, "%s", e.getMessage());
+      }
+    };
+  }
+
   public static FunctionOp callInStrStrStrOutStr(TriFunction<String, String, String, String> func) {
     return values -> {
-      if (values.length != 3) {
-        return Err.maybeNoSuchOverloadErr(null);
-      }
-      if (values[0].type() != StringT.StringType) {
-        return Err.maybeNoSuchOverloadErr(values[0]);
-      }
-      if (values[1].type() != StringT.StringType) {
-        return Err.maybeNoSuchOverloadErr(values[1]);
-      }
-      if (values[2].type() != StringT.StringType) {
-        return Err.maybeNoSuchOverloadErr(values[2]);
-      }
       try {
         return StringT.stringOf(
             func.apply(
@@ -104,11 +119,24 @@ public final class Guards {
     };
   }
 
+  public static FunctionOp callInStrStrStrIntOutStr(
+      QuadFunction<String, String, String, Integer, String> func) {
+    return values -> {
+      try {
+        return StringT.stringOf(
+            func.apply(
+                ((String) values[0].value()),
+                ((String) values[1].value()),
+                ((String) values[2].value()),
+                getIntValue((IntT) values[3])));
+      } catch (RuntimeException e) {
+        return Err.newErr(e, "%s", e.getMessage());
+      }
+    };
+  }
+
   public static UnaryOp callInStrOutStr(UnaryOperator<String> func) {
     return val -> {
-      if (val.type() != StringT.StringType) {
-        return Err.maybeNoSuchOverloadErr(val);
-      }
       try {
         return StringT.stringOf(func.apply(((String) val.value())));
       } catch (RuntimeException e) {

--- a/core/src/test/java/org/projectnessie/cel/extension/StringsTest.java
+++ b/core/src/test/java/org/projectnessie/cel/extension/StringsTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.*;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.projectnessie.cel.Env;
@@ -46,53 +47,44 @@ public class StringsTest {
         new TestData("'tacocat'.indexOf('') == 0"),
         new TestData("'tacocat'.indexOf('ac') == 1"),
         new TestData("'tacocat'.indexOf('none') == -1"),
-        /*
-            new TestData("'tacocat'.indexOf('', 3) == 3"),
-            new TestData("'tacocat'.indexOf('a', 3) == 5"),
-            new TestData("'tacocat'.indexOf('at', 3) == 5"),
-        */
+        new TestData("'tacocat'.indexOf('', 3) == 3"),
+        new TestData("'tacocat'.indexOf('a', 3) == 5"),
+        new TestData("'tacocat'.indexOf('at', 3) == 5"),
         new TestData("'ta©o©αT'.indexOf('©') == 2"),
-        /*
-            new TestData("'ta©o©αT'.indexOf('©', 3) == 4"),
-            new TestData("'ta©o©αT'.indexOf('©αT', 3) == 4"),
-            new TestData("'ta©o©αT'.indexOf('©α', 5) == -1"),
-        */
+        new TestData("'ta©o©αT'.indexOf('©', 3) == 4"),
+        new TestData("'ta©o©αT'.indexOf('©αT', 3) == 4"),
+        new TestData("'ta©o©αT'.indexOf('©α', 5) == -1"),
         new TestData("'tacocat'.lastIndexOf('') == 7"),
         new TestData("'tacocat'.lastIndexOf('at') == 5"),
         new TestData("'tacocat'.lastIndexOf('none') == -1"),
-        /*
-            new TestData("'tacocat'.lastIndexOf('', 3) == 3"),
-            new TestData("'tacocat'.lastIndexOf('a', 3) == 1"),
-        */
+        new TestData("'tacocat'.lastIndexOf('', 3) == 3"),
+        new TestData("'tacocat'.lastIndexOf('a', 3) == 1"),
         new TestData("'ta©o©αT'.lastIndexOf('©') == 4"),
-        /*
-            new TestData("'ta©o©αT'.lastIndexOf('©', 3) == 2"),
-            new TestData("'ta©o©αT'.lastIndexOf('©α', 4) == 4"),
-        */
+        new TestData("'ta©o©αT'.lastIndexOf('©', 3) == 2"),
+        new TestData("'ta©o©αT'.lastIndexOf('©α', 4) == 4"),
         new TestData("'TacoCat'.lowerAscii() == 'tacocat'"),
         new TestData("'TacoCÆt Xii'.lowerAscii() == 'tacocÆt xii'"),
         new TestData("'hello hello'.replace('he', 'we') == 'wello wello'"),
+        new TestData("'hello hello'.replace('he', 'we', -1) == 'wello wello'"),
+        new TestData("'hello hello'.replace('he', 'we', 1)  == 'wello hello'"),
+        new TestData("'hello hello'.replace('he', 'we', 0) == 'hello hello'"),
         new TestData("\"12 days 12 hours\".replace(\"{0}\", \"2\") == \"12 days 12 hours\""),
         new TestData("\"{0} days {0} hours\".replace(\"{0}\", \"2\") == \"2 days 2 hours\""),
-        /*
-            new TestData("\"{0} days {0} hours\".replace(\"{0}\", \"2\", 1).replace(\"{0}\", \"23\") == \"2 days 23 hours\""),
-        */
+        new TestData(
+            "\"{0} days {0} hours\".replace(\"{0}\", \"2\", 1).replace(\"{0}\", \"23\") == \"2 days 23 hours\""),
         new TestData("\"1 ©αT taco\".replace(\"αT\", \"o©α\") == \"1 ©o©α taco\""),
         new TestData("'hello hello hello'.split(' ') == ['hello', 'hello', 'hello']"),
         new TestData("\"hello world\".split(\" \") == [\"hello\", \"world\"]"),
-        /*
-            new TestData("\"hello world events!\".split(\" \", 0) == []"),
-            new TestData("\"hello world events!\".split(\" \", 1) == [\"hello world events!\"]"),
-            new TestData("\"o©o©o©o\".split(\"©\", -1) == [\"o\", \"o\", \"o\", \"o\"]"),
-        */
+        new TestData("\"hello world events!\".split(\" \", 0) == []"),
+        new TestData("\"hello world events!\".split(\" \", 1) == [\"hello world events!\"]"),
+        new TestData("\"hello world events!\".split(\" \", 2) == [\"hello\", \"world events!\"]"),
+        new TestData("\"o©o©o©o\".split(\"©\", -1) == [\"o\", \"o\", \"o\", \"o\"]"),
         new TestData("\"tacocat\".substring(4) == \"cat\""),
         new TestData("\"tacocat\".substring(7) == \"\""),
-        /*
-            new TestData("\"tacocat\".substring(0, 4) == \"taco\""),
-            new TestData("\"tacocat\".substring(4, 4) == \"\""),
-            new TestData("'ta©o©αT'.substring(2, 6) == \"©o©α\""),
-            new TestData("'ta©o©αT'.substring(7, 7) == \"\""),
-        */
+        new TestData("\"tacocat\".substring(0, 4) == \"taco\""),
+        new TestData("\"tacocat\".substring(4, 4) == \"\""),
+        new TestData("'ta©o©αT'.substring(2, 6) == \"©o©α\""),
+        new TestData("'ta©o©αT'.substring(7, 7) == \"\""),
         new TestData("'TacoCat'.upperAscii() == 'TACOCAT'"),
         new TestData("'TacoCÆt Xii'.upperAscii() == 'TACOCÆT XII'"),
         new TestData("\" \\f\\n\\r\\t\\vtext  \".trim() == \"text\""),
@@ -105,12 +97,9 @@ public class StringsTest {
             "\"\u180etext\u200b\u200c\u200d\u2060\ufeff\".trim() == \"\u180etext\u200b\u200c\u200d\u2060\ufeff\""),
 
         // Error test cases based on checked expression usage.
-        /*
-                new TestData("'tacocat'.indexOf('a', 30) == -1", "String index out of range: 30"),
-                new TestData("'tacocat'.lastIndexOf('a', -1) == -1", "String index out of range: -1"),
-                new TestData("'tacocat'.lastIndexOf('a', 30) == -1", "String index out of range: 30"),
-        */
-
+        new TestData("'tacocat'.indexOf('a', 30) == -1", "String index out of range: 30"),
+        new TestData("'tacocat'.lastIndexOf('a', -1) == -1", "String index out of range: -1"),
+        new TestData("'tacocat'.lastIndexOf('a', 30) == -1", "String index out of range: 30"),
         new TestData(
             "\"tacocat\".substring(40) == \"cat\"",
             "String index out of range: -33",
@@ -129,12 +118,10 @@ public class StringsTest {
                 put(14, "begin -1, end 7, length 7");
               }
             }),
-        /*
-                new TestData("\"tacocat\".substring(1, 50) == \"cat\"", "String index out of range: 50"),
-                new TestData("\"tacocat\".substring(49, 50) == \"cat\"", "String index out of range: 49"),
-                new TestData(
-                    "\"tacocat\".substring(4, 3) == \"\"", "invalid substring range. start: 4, end: 3"),
-        */
+        new TestData("\"tacocat\".substring(1, 50) == \"cat\"", "String index out of range: 50"),
+        new TestData("\"tacocat\".substring(49, 50) == \"cat\"", "String index out of range: 49"),
+        new TestData(
+            "\"tacocat\".substring(4, 3) == \"\"", "invalid substring range. start: 4, end: 3"),
 
         // Valid parse-only expressions which should generate runtime errors.
         new TestData("42.charAt(2) == \"\"", "no matching overload", true),
@@ -171,6 +158,52 @@ public class StringsTest {
         new TestData("30.substring(true, 3) == \"\"", "no matching overload", true),
         new TestData("\"tacocat\".substring(true, 3) == \"\"", "no matching overload", true),
         new TestData("\"tacocat\".substring(0, false) == \"\"", "no matching overload", true));
+  }
+
+  @Test
+  public void testReplaceN() {
+    assertThat(StringsLib.replaceN("hello hello hello xyz hello", "hello", "hello", -1))
+        .isEqualTo("hello hello hello xyz hello");
+    assertThat(StringsLib.replaceN("hello hello hello xyz hello", "hello", "abcd", -1))
+        .isEqualTo("abcd abcd abcd xyz abcd");
+    assertThat(StringsLib.replaceN("hello hello hello xyz hello", "hello", "abcd", 0))
+        .isEqualTo("hello hello hello xyz hello");
+    assertThat(StringsLib.replaceN("hello hello hello xyz hello", "hello", "abcd", 1))
+        .isEqualTo("abcd hello hello xyz hello");
+    assertThat(StringsLib.replaceN("hello hello hello xyz hello", "hello", "abcd", 2))
+        .isEqualTo("abcd abcd hello xyz hello");
+    assertThat(StringsLib.replaceN("hello hello hello xyz hello ", "hello", "abcd", 4))
+        .isEqualTo("abcd abcd abcd xyz abcd ");
+    assertThat(StringsLib.replaceN("hello hello hello xyz hello ", "hello", "abcd", 100))
+        .isEqualTo("abcd abcd abcd xyz abcd ");
+    assertThat(StringsLib.replaceN("hello hello hello xyz hello ", "", "abcd", 2))
+        .isEqualTo("abcdhabcdello hello hello xyz hello ");
+  }
+
+  @Test
+  public void testSplitN() {
+    assertThat(StringsLib.splitN("A B C D E", " ", 0)).isEqualTo(new String[] {});
+    assertThat(StringsLib.splitN("A B C D E", " ", 1)).isEqualTo(new String[] {"A B C D E"});
+    assertThat(StringsLib.splitN("A B C D E", " ", 2)).isEqualTo(new String[] {"A", "B C D E"});
+    assertThat(StringsLib.splitN("A B C D E", " ", 3)).isEqualTo(new String[] {"A", "B", "C D E"});
+    assertThat(StringsLib.splitN("A B C D E", " ", 4))
+        .isEqualTo(new String[] {"A", "B", "C", "D E"});
+    assertThat(StringsLib.splitN("A B C D E", " ", 5))
+        .isEqualTo(new String[] {"A", "B", "C", "D", "E"});
+    assertThat(StringsLib.splitN("A B C D E", " ", 100))
+        .isEqualTo(new String[] {"A", "B", "C", "D", "E"});
+    assertThat(StringsLib.splitN("A B C D E", " ", -100))
+        .isEqualTo(new String[] {"A", "B", "C", "D", "E"});
+
+    assertThat(StringsLib.splitN(" A B C ", " ", 5))
+        .isEqualTo(new String[] {"", "A", "B", "C", ""});
+
+    assertThat(StringsLib.splitN("", " ", 5)).isEqualTo(new String[] {""});
+    // edge cases, sep is empty string
+    assertThat(StringsLib.splitN("A B C", "", 2)).isEqualTo(new String[] {"A", " B C"});
+    assertThat(StringsLib.splitN("A B C", "", 5)).isEqualTo(new String[] {"A", " ", "B", " ", "C"});
+    assertThat(StringsLib.splitN("A B C", "", 100))
+        .isEqualTo(new String[] {"A", " ", "B", " ", "C"});
   }
 
   private static void testExpression(TestData testData) {


### PR DESCRIPTION
https://github.com/projectnessie/cel-java/issues/103 for multiple overloads:

- `indexOf`, providing new format with optional argument for starting position
- `lastIndexOf`, similar change as `indexOf`
- `replace`, providing optional argument for replace count
- `split`, providing optional argument for split count
- `substring`, providing optional argument for trailing range 
The javadocs and test cases were updated accordingly.

On implementation, `ProgramOptions` are updated to include these overloads, benefitting from https://github.com/projectnessie/cel-java/issues/110. 
The `replace` function is tricky as it may take 3 or 4 arguments which are represented as `FunctionOp`. The `FunctionOp` is made to execute different guard functions based on argument count.

The `replaceN` and `splitN` functionalities are new in Java. So porting them from Go.

