### PR TITLE
CI: Unify bazel cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,8 +65,8 @@ jobs:
         with:
           path: |
             ~/.cache/bazel
-          key: bazel-${{ matrix.java-version }}-${{ hashFiles('**/.gitmodules') }}
-          restore-keys: bazel-${{ matrix.java-version }}
+          key: bazel-${{ hashFiles('**/.gitmodules') }}
+          restore-keys: bazel-
 
       - name: Setup bazel
         uses: jwlawson/actions-setup-bazel@v1.7.0


### PR DESCRIPTION
The bazel build (for the conformance tests) does not depend on the Java version, so there should be only one cache-key for the bazel-cache.