### PR TITLE
CI: Remove path restrictions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,21 +17,7 @@ name: CI
 on:
   push:
     branches: [ main ]
-    paths-ignore:
-      - 'LICENSE'
-      - '*.md'
-      - '**/*.md'
-      - '.github/dependabot.yml'
-      - '.github/workflows/release.yml'
-      - '.idea/**'
   pull_request:
-    paths-ignore:
-      - 'LICENSE'
-      - '*.md'
-      - '**/*.md'
-      - '.github/dependabot.yml'
-      - '.github/workflows/release.yml'
-      - '.idea/**'
 
 jobs:
   java:


### PR DESCRIPTION
Pushes to `main` + PRs only cause CI to run for source-code paths, but not for other changes.
Those "other changes" - e.g. to README.md and GH workflows - cause CI to not run and hence
don't let the PR "become green".

Removing the `paths-ignore` lets CI run and the commit-status become green.