### PR TITLE
Handle the case when `~/.gradle` does not exist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
         run: |
+          mkdir -p ~/.gradle
           echo "sonatypeUsername=${{ secrets.OSSRH_ACCESS_ID }}" >> ~/.gradle/gradle.properties
           echo "sonatypePassword=${{ secrets.OSSRH_TOKEN }}" >> ~/.gradle/gradle.properties
 


### PR DESCRIPTION
... for example when GitHub expired the Gradle cache.

As here: https://github.com/projectnessie/cel-java/runs/5973722511?check_suite_focus=true