### PR TITLE
Centralize dependency management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,31 +8,3 @@ updates:
   directory: "/build-tools/"
   schedule:
     interval: daily
-- package-ecosystem: gradle
-  directory: "/conformance/"
-  schedule:
-    interval: daily
-- package-ecosystem: gradle
-  directory: "/core/"
-  schedule:
-    interval: daily
-- package-ecosystem: gradle
-  directory: "/jackson/"
-  schedule:
-    interval: daily
-- package-ecosystem: gradle
-  directory: "/jacoco/"
-  schedule:
-    interval: daily
-- package-ecosystem: gradle
-  directory: "/generated-antlr/"
-  schedule:
-    interval: daily
-- package-ecosystem: gradle
-  directory: "/generated-pb/"
-  schedule:
-    interval: daily
-- package-ecosystem: gradle
-  directory: "/tools/"
-  schedule:
-    interval: daily

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ plugins {
   eclipse
   idea
   signing
+  `java-platform`
   `maven-publish`
   id("org.jetbrains.gradle.plugin.idea-ext")
   id("com.diffplug.spotless")
@@ -31,7 +32,49 @@ plugins {
   id("io.github.gradle-nexus.publish-plugin")
 }
 
+val versionAgrona = "1.15.2"
+val versionAntlr = "4.10.1"
+val versionAssertj = "3.22.0"
+val versionGrpc = "1.46.0"
+val versionImmutables = "2.9.0"
+val versionJackson = "2.13.2"
 var versionJacoco = "0.8.7"
+val versionJmh = "1.35"
+val versionJSR305 = "3.0.2"
+val versionJunit = "5.8.2"
+val versionProtobuf = "3.20.1"
+val versionTomcatAnnotationsApi = "6.0.53"
+
+extra["versionGrpc"] = versionGrpc
+
+extra["versionJmh"] = versionJmh
+
+extra["versionProtobuf"] = versionProtobuf
+
+dependencies {
+  constraints {
+    api("com.fasterxml.jackson.core:jackson-databind:$versionJackson")
+    api("com.fasterxml.jackson.dataformat:jackson-dataformat-protobuf:$versionJackson")
+    api("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$versionJackson")
+    api("com.google.code.findbugs:jsr305:$versionJSR305")
+    api("com.google.protobuf:protobuf-java:$versionProtobuf")
+    api("org.agrona:agrona:$versionAgrona")
+    api("org.antlr:antlr4:$versionAntlr") // TODO remove from runtime-classpath *sigh*
+    api("org.antlr:antlr4-runtime:$versionAntlr")
+    api("org.apache.tomcat:annotations-api:$versionTomcatAnnotationsApi")
+    api("org.assertj:assertj-core:$versionAssertj")
+    api("org.immutables:value-processor:$versionImmutables")
+    api("org.immutables:value-annotations:$versionImmutables")
+    api("org.junit.jupiter:junit-jupiter-api:$versionJunit")
+    api("org.junit.jupiter:junit-jupiter-params:$versionJunit")
+    api("org.junit.jupiter:junit-jupiter-engine:$versionJunit")
+    api("org.openjdk.jmh:jmh-core:$versionJmh")
+    api("org.openjdk.jmh:jmh-generator-annprocess:$versionJmh")
+    api("io.grpc:grpc-protobuf:$versionGrpc")
+    api("io.grpc:grpc-stub:$versionGrpc")
+    api("io.grpc:grpc-netty-shaded:$versionGrpc")
+  }
+}
 
 allprojects {
   repositories { mavenCentral() }
@@ -145,11 +188,7 @@ allprojects {
           }
 
           if (project.name != "generated-antlr") {
-            if (project.name != "bom") {
-              from(components.findByName("java"))
-            } else {
-              from(components.findByName("javaPlatform"))
-            }
+            from(components.firstOrNull { c -> c.name == "javaPlatform" || c.name == "java" })
           }
         }
       }
@@ -253,6 +292,8 @@ allprojects {
     }
   }
 }
+
+javaPlatform { allowDependencies() }
 
 spotless {
   kotlinGradle {

--- a/conformance/build.gradle.kts
+++ b/conformance/build.gradle.kts
@@ -28,31 +28,30 @@ plugins {
     id("org.caffinitas.gradle.testrerun")
 }
 
-val versionAssertj = "3.22.0"
-val versionJunit = "5.8.2"
-val versionGrpc = "1.46.0"
-val versionProtobuf = "3.20.1"
-
 sourceSets.main {
     java.srcDir(project.buildDir.resolve("generated/source/proto/main/java"))
 }
 
 dependencies {
+    implementation(platform(rootProject))
+
     implementation(project(":core"))
     implementation(project(":core", "testJar"))
     implementation(project(":generated-pb", "testJar"))
 
-    implementation("com.google.protobuf:protobuf-java:$versionProtobuf")
+    implementation("com.google.protobuf:protobuf-java")
 
-    implementation("io.grpc:grpc-protobuf:$versionGrpc")
-    implementation("io.grpc:grpc-stub:$versionGrpc")
-    runtimeOnly("io.grpc:grpc-netty-shaded:$versionGrpc")
-    compileOnly("org.apache.tomcat:annotations-api:6.0.53")
+    implementation("io.grpc:grpc-protobuf")
+    implementation("io.grpc:grpc-stub")
+    runtimeOnly("io.grpc:grpc-netty-shaded")
+    compileOnly("org.apache.tomcat:annotations-api")
 
-    testImplementation("org.assertj:assertj-core:$versionAssertj")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:$versionJunit")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:$versionJunit")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$versionJunit")
+    testImplementation(platform(rootProject))
+
+    testImplementation("org.assertj:assertj-core")
+    testImplementation("org.junit.jupiter:junit-jupiter-api")
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }
 
 tasks.named<Jar>("shadowJar") {
@@ -66,7 +65,7 @@ protobuf {
     // Configure the protoc executable
     protobuf.protoc {
         // Download from repositories
-        artifact = "com.google.protobuf:protoc:$versionProtobuf"
+        artifact = "com.google.protobuf:protoc:${rootProject.extra["versionProtobuf"]}"
     }
 }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -26,29 +26,31 @@ plugins {
     id("org.caffinitas.gradle.testrerun")
 }
 
-val versionAgrona = "1.15.2"
-val versionAssertj = "3.22.0"
-val versionJmh = "1.35"
-val versionJunit = "5.8.2"
-
 dependencies {
     implementation(project(":generated-antlr", "shadow"))
     api(project(":generated-pb"))
 
-    implementation("org.agrona:agrona:$versionAgrona")
+    implementation(platform(rootProject))
+
+    implementation("org.agrona:agrona")
+
+    testImplementation(platform(rootProject))
 
     testImplementation(project(":generated-pb", "testJar"))
-    testImplementation("org.assertj:assertj-core:$versionAssertj")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:$versionJunit")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:$versionJunit")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$versionJunit")
+    testImplementation("org.assertj:assertj-core")
+    testImplementation("org.junit.jupiter:junit-jupiter-api")
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
-    jmhImplementation("org.openjdk.jmh:jmh-core:$versionJmh")
-    jmhAnnotationProcessor("org.openjdk.jmh:jmh-generator-annprocess:$versionJmh")
+    jmhImplementation(platform(rootProject))
+    jmhAnnotationProcessor(platform(rootProject))
+
+    jmhImplementation("org.openjdk.jmh:jmh-core")
+    jmhAnnotationProcessor("org.openjdk.jmh:jmh-generator-annprocess")
 }
 
 jmh {
-    jmhVersion.set(versionJmh)
+    jmhVersion.set(rootProject.extra["versionJmh"] as String)
 }
 
 val testJar by configurations.creating {

--- a/generated-antlr/build.gradle.kts
+++ b/generated-antlr/build.gradle.kts
@@ -24,11 +24,11 @@ plugins {
     id("com.github.johnrengelman.shadow")
 }
 
-val versionAntlr = "4.10.1"
-
 dependencies {
-    antlr("org.antlr:antlr4:$versionAntlr") // TODO remove from runtime-classpath *sigh*
-    implementation("org.antlr:antlr4-runtime:$versionAntlr")
+    antlr(platform(rootProject))
+    antlr("org.antlr:antlr4") // TODO remove from runtime-classpath *sigh*
+    implementation(platform(rootProject))
+    implementation("org.antlr:antlr4-runtime")
 }
 
 // The antlr-plugin should ideally do this

--- a/generated-pb/build.gradle.kts
+++ b/generated-pb/build.gradle.kts
@@ -26,9 +26,6 @@ plugins {
     id("org.projectnessie.cel.reflectionconfig")
 }
 
-val versionGrpc = "1.46.0"
-val versionProtobuf = "3.20.1"
-
 sourceSets.main {
     java.srcDir(project.buildDir.resolve("generated/source/proto/main/java"))
     java.srcDir(project.buildDir.resolve("generated/source/proto/main/grpc"))
@@ -40,13 +37,15 @@ sourceSets.test {
 }
 
 dependencies {
-    api("com.google.protobuf:protobuf-java:$versionProtobuf")
+    api(platform(rootProject))
+
+    api("com.google.protobuf:protobuf-java")
 
     // Since we need the protobuf stuff in this cel-core module, it's easy to generate the
     // gRPC code as well. But do not expose the gRPC dependencies "publicly".
-    compileOnly("io.grpc:grpc-protobuf:$versionGrpc")
-    compileOnly("io.grpc:grpc-stub:$versionGrpc")
-    compileOnly("org.apache.tomcat:annotations-api:6.0.53")
+    compileOnly("io.grpc:grpc-protobuf")
+    compileOnly("io.grpc:grpc-stub")
+    compileOnly("org.apache.tomcat:annotations-api")
 }
 
 // *.proto files taken from https://github.com/googleapis/googleapis/ repo, available as a git submodule
@@ -54,11 +53,11 @@ protobuf {
     // Configure the protoc executable
     protobuf.protoc {
         // Download from repositories
-        artifact = "com.google.protobuf:protoc:$versionProtobuf"
+        artifact = "com.google.protobuf:protoc:${rootProject.extra["versionProtobuf"]}"
     }
     protobuf.plugins {
         this.create("grpc") {
-            artifact = "io.grpc:protoc-gen-grpc-java:$versionGrpc"
+            artifact = "io.grpc:protoc-gen-grpc-java:${rootProject.extra["versionGrpc"]}"
         }
     }
     protobuf.generateProtoTasks {

--- a/jackson/build.gradle.kts
+++ b/jackson/build.gradle.kts
@@ -25,25 +25,22 @@ plugins {
     id("org.caffinitas.gradle.testrerun")
 }
 
-val versionAssertj = "3.22.0"
-val versionImmutables = "2.9.0"
-val versionJackson = "2.13.3"
-val versionJSR305 = "3.0.2"
-val versionJunit = "5.8.2"
-
 dependencies {
     api(project(":core"))
 
-    implementation("com.fasterxml.jackson.core:jackson-databind:$versionJackson")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-protobuf:$versionJackson")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$versionJackson")
+    implementation(platform(rootProject))
+    implementation("com.fasterxml.jackson.core:jackson-databind")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-protobuf")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
 
+    testImplementation(platform(rootProject))
+    testAnnotationProcessor(platform(rootProject))
     testImplementation(project(":tools"))
-    testAnnotationProcessor("org.immutables:value-processor:$versionImmutables")
-    testCompileOnly("org.immutables:value-annotations:$versionImmutables")
-    testImplementation("com.google.code.findbugs:jsr305:$versionJSR305")
-    testImplementation("org.assertj:assertj-core:$versionAssertj")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:$versionJunit")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:$versionJunit")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$versionJunit")
+    testAnnotationProcessor("org.immutables:value-processor")
+    testCompileOnly("org.immutables:value-annotations")
+    testImplementation("com.google.code.findbugs:jsr305")
+    testImplementation("org.assertj:assertj-core")
+    testImplementation("org.junit.jupiter:junit-jupiter-api")
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }

--- a/tools/build.gradle.kts
+++ b/tools/build.gradle.kts
@@ -25,14 +25,12 @@ plugins {
     id("org.caffinitas.gradle.testrerun")
 }
 
-val versionAssertj = "3.22.0"
-val versionJunit = "5.8.2"
-
 dependencies {
     api(project(":core"))
 
-    testImplementation("org.assertj:assertj-core:$versionAssertj")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:$versionJunit")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:$versionJunit")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$versionJunit")
+    testImplementation(platform(rootProject))
+    testImplementation("org.assertj:assertj-core")
+    testImplementation("org.junit.jupiter:junit-jupiter-api")
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }


### PR DESCRIPTION
Move dependency definitions into the root project, let the root project become
a "platform" (think: bom) and pull that into the child projects.

GH dependabot only needs to scan the root project, not every child project.