### PR TITLE
Switch to gradle/gradle-build-action for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,21 +31,33 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'true'
+
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java-version }}
 
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
+      - name: Build with Gradle
+        # Java 8 and 16+ don't run spotless, because google-java-format requires Java 11+ (but doesn't run w/ Java 16)
+        uses: gradle/gradle-build-action@v2
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            ~/.m2/repository
-          key: gradle-${{ matrix.java-version }}-${{ hashFiles('**/*.gradle.kts') }}-${{ hashFiles('**/.gitmodules') }}
-          restore-keys: gradle-${{ matrix.java-version }}
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          arguments: --rerun-tasks --info assemble check publishToMavenLocal -x jmh
+
+      - name: Build tool integrations
+        # The buildToolIntegration* tasks require publishToMavenLocal, run it as a separate step,
+        # because these tasks intentionally do not depend on the publishToMavenLocal tasks.
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          arguments: buildToolIntegrations
+
+      - name: Microbenchmarks
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          arguments: jmh
 
       - name: Cache Bazel stuff
         uses: actions/cache@v3
@@ -59,24 +71,6 @@ jobs:
         uses: jwlawson/actions-setup-bazel@v1.7.0
         with:
           bazel-version: '3.5.1'
-
-      - name: Build with Gradle
-        # Java 8 and 16+ don't run spotless, because google-java-format requires Java 11+ (but doesn't run w/ Java 16)
-        run: |
-          if [[ ${{ matrix.java-version }} -ge 16 ]] ; then
-            ADDITIONAL_ARGS="-x spotlessCheck"
-          fi
-          ./gradlew --rerun-tasks --no-daemon --info assemble check publishToMavenLocal -x jmh ${ADDITIONAL_ARGS}
-
-      - name: Build tool integrations
-        # The buildToolIntegration* tasks require publishToMavenLocal, run it as a separate step,
-        # because these tasks intentionally do not depend on the publishToMavenLocal tasks.
-        run: |
-          ./gradlew buildToolIntegrations
-
-      - name: Microbenchmarks
-        run: |
-          ./gradlew jmh
 
       - name: Conformance tests
         run: |
@@ -112,4 +106,4 @@ jobs:
       - name: Test with Gradle (Java 8)
         if: ${{ matrix.java-version == '11' }}
         run: |
-          ./gradlew test -PtestRerun
+          ./gradlew test -PtestRerun -Dorg.gradle.jvmargs=""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,15 +69,6 @@ jobs:
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ matrix.java-version }}-${{ hashFiles('**/*.gradle.kts') }}-${{ hashFiles('**/.gitmodules') }}
-          restore-keys: gradle-${{ matrix.java-version }}
-
       - name: Configure release-bot-user in git config
         run: |
           git config --global user.email "cel-java-release-noreply@projectnessie.org"
@@ -108,7 +99,11 @@ jobs:
           echo "sonatypeUsername=${{ secrets.OSSRH_ACCESS_ID }}" >> ~/.gradle/gradle.properties
           echo "sonatypePassword=${{ secrets.OSSRH_TOKEN }}" >> ~/.gradle/gradle.properties
 
-          ./gradlew --rerun-tasks --no-daemon --info assemble check publishToMavenLocal -x jmh publishToSonatype closeAndReleaseSonatypeStagingRepository -Prelease
+      - name: Publish to Sonatype
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: true
+          arguments: --rerun-tasks --info assemble check publishToMavenLocal -x jmh publishToSonatype closeAndReleaseSonatypeStagingRepository -Prelease
 
       - name: Bump to next development version
         run: echo "${NEXT_VERSION}-SNAPSHOT" > version.txt

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,18 @@
+# enable the Gradle build cache
+org.gradle.caching=true
+# enable Gradle parallel builds
+org.gradle.parallel=true
+# configure only necessary Gradle tasks
+org.gradle.configureondemand=true\
+#
+org.gradle.jvmargs=\
+  --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED


### PR DESCRIPTION
The [Gradle Github action](https://github.com/gradle/gradle-build-action) utilizes the caches for GH actions much better than it could be done manually: fine grained control of the various Gradle caches and read-only caches for PRs.