### PR TITLE
Do not publish build dependencies

### DIFF
--- a/build-tool-integ-tests/src/main/java/MyClass.java
+++ b/build-tool-integ-tests/src/main/java/MyClass.java
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import com.google.api.expr.v1alpha1.ConformanceServiceGrpc;
 import com.google.api.expr.v1alpha1.Decl;
 import org.projectnessie.cel.checker.Decls;
 import org.projectnessie.cel.tools.ScriptHost;

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,11 @@ val versionJunit = "5.8.2"
 val versionProtobuf = "3.20.1"
 val versionTomcatAnnotationsApi = "6.0.53"
 
+extra["versionAgrona"] = versionAgrona
+
 extra["versionGrpc"] = versionGrpc
+
+extra["versionJackson"] = versionJackson
 
 extra["versionJmh"] = versionJmh
 
@@ -59,7 +63,7 @@ dependencies {
     api("com.google.code.findbugs:jsr305:$versionJSR305")
     api("com.google.protobuf:protobuf-java:$versionProtobuf")
     api("org.agrona:agrona:$versionAgrona")
-    api("org.antlr:antlr4:$versionAntlr") // TODO remove from runtime-classpath *sigh*
+    api("org.antlr:antlr4:$versionAntlr")
     api("org.antlr:antlr4-runtime:$versionAntlr")
     api("org.apache.tomcat:annotations-api:$versionTomcatAnnotationsApi")
     api("org.assertj:assertj-core:$versionAssertj")
@@ -187,7 +191,9 @@ allprojects {
             }
           }
 
-          if (project.name != "generated-antlr") {
+          // Must exclude the `generated-antlr` project, because otherwise its `antlr` configuration
+          // leaks antlr dependencies downstream.
+          if (project.name != "generated-antlr" && project != rootProject) {
             from(components.firstOrNull { c -> c.name == "javaPlatform" || c.name == "java" })
           }
         }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -30,10 +30,11 @@ dependencies {
     implementation(project(":generated-antlr", "shadow"))
     api(project(":generated-pb"))
 
-    implementation(platform(rootProject))
+    compileOnly(platform(rootProject))
 
-    implementation("org.agrona:agrona")
+    implementation("org.agrona:agrona:${rootProject.extra["versionAgrona"]}")
 
+    testImplementation(platform(rootProject))
     testImplementation(project(":generated-pb", "testJar"))
     testImplementation("org.assertj:assertj-core")
     testImplementation("org.junit.jupiter:junit-jupiter-api")

--- a/generated-antlr/build.gradle.kts
+++ b/generated-antlr/build.gradle.kts
@@ -27,7 +27,7 @@ plugins {
 dependencies {
     antlr(platform(rootProject))
     antlr("org.antlr:antlr4") // TODO remove from runtime-classpath *sigh*
-    implementation(platform(rootProject))
+    compileOnly(platform(rootProject))
     implementation("org.antlr:antlr4-runtime")
 }
 

--- a/generated-pb/build.gradle.kts
+++ b/generated-pb/build.gradle.kts
@@ -37,9 +37,9 @@ sourceSets.test {
 }
 
 dependencies {
-    api(platform(rootProject))
+    compileOnly(platform(rootProject))
 
-    api("com.google.protobuf:protobuf-java")
+    api("com.google.protobuf:protobuf-java:${rootProject.extra["versionProtobuf"]}")
 
     // Since we need the protobuf stuff in this cel-core module, it's easy to generate the
     // gRPC code as well. But do not expose the gRPC dependencies "publicly".

--- a/jackson/build.gradle.kts
+++ b/jackson/build.gradle.kts
@@ -28,11 +28,12 @@ plugins {
 dependencies {
     api(project(":core"))
 
-    implementation(platform(rootProject))
-    implementation("com.fasterxml.jackson.core:jackson-databind")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-protobuf")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
+    compileOnly(platform(rootProject))
+    implementation("com.fasterxml.jackson.core:jackson-databind:${rootProject.extra["versionJackson"]}")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-protobuf:${rootProject.extra["versionJackson"]}")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${rootProject.extra["versionJackson"]}")
 
+    testImplementation(platform(rootProject))
     testAnnotationProcessor(platform(rootProject))
     testImplementation(project(":tools"))
     testAnnotationProcessor("org.immutables:value-processor")


### PR DESCRIPTION
Before #173 the published `cel-parent` pom contained no Maven
`<dependencyManagement>`. With #173, it appeared, which lets
CEL-Java's *build* dependencies leak into other projects.
Especially the dependency to antlr can cause issues downstream.

Similar for the published Gradle `module.json`s - here the
`cel-parent` must become a `compileOnly` dependency, so it
does not "leak" downstream.