### PR TITLE
Fix Java 8 compatibiltiy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,17 +32,46 @@ jobs:
         with:
           submodules: 'true'
 
+      # Special handling to test against Java 8:
+      # antlr version 4.10 requires Java 11 to run the antlr tool, but tests still need to run
+      # against Java 8 - that's being done here:
+      - name: Set up Java 8
+        if: ${{ matrix.java-version == '11' }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 8
+      - name: Configure env with Java 8 home
+        if: ${{ matrix.java-version == '11' }}
+        run:
+          echo "JAVA_8_HOME=$JAVA_HOME" >> $GITHUB_ENV
+      - name: Enable Java 8 tests
+        if: ${{ matrix.java-version == '11' }}
+        run:
+          echo "ADDITIONAL_GRADLE_OPTS=-PalsoTestAgainstJava8" >> $GITHUB_ENV
+      - name: Configure Java 8 home for Gradle
+        if: ${{ matrix.java-version == '11' }}
+        run: |
+          mkdir -p $HOME/.gradle
+          echo "org.gradle.java.installations.fromEnv=JAVA_8_HOME" >> $HOME/.gradle/gradle.properties
+
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java-version }}
 
-      - name: Build with Gradle
-        # Java 8 and 16+ don't run spotless, because google-java-format requires Java 11+ (but doesn't run w/ Java 16)
+      - name: Spotless Check
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: --rerun-tasks --info assemble check publishToMavenLocal -x jmh
+          # Spotless must run in a different invocation, because
+          # it has some weird Gradle configuration/variant issue
+          arguments: spotlessCheck
+
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: --rerun-tasks assemble ${{ env.ADDITIONAL_GRADLE_OPTS }} check publishToMavenLocal -x jmh -x spotlessCheck
 
       - name: Build tool integrations
         # The buildToolIntegration* tasks require publishToMavenLocal, run it as a separate step,
@@ -87,20 +116,3 @@ jobs:
           path: |
             **/build/reports/*
             **/build/test-results/*
-
-      # Special handling to test against Java 8:
-      # antlr version 4.10 requires Java 11 to run the antlr tool, but tests still need to run
-      # against Java 8 - that's being done here:
-      - name: Stop running Gradle Daemon (Java 8)
-        if: ${{ matrix.java-version == '11' }}
-        run: ./gradlew --stop
-      - name: Set up Java (Java 8)
-        if: ${{ matrix.java-version == '11' }}
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: 8
-      - name: Test with Gradle (Java 8)
-        if: ${{ matrix.java-version == '11' }}
-        run: |
-          ./gradlew --no-daemon test -PtestRerun -Dorg.gradle.jvmargs=""

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,6 +88,28 @@ allprojects {
       useJUnitPlatform {}
       maxParallelForks = Runtime.getRuntime().availableProcessors()
     }
+
+    if (project.hasProperty("alsoTestAgainstJava8")) {
+      afterEvaluate {
+        val javaToolchains = extensions.findByType(JavaToolchainService::class.java)
+        if (javaToolchains != null) {
+          val testWithJava8 =
+            tasks.register<Test>("testWithJava8") {
+              group = "verification"
+              description = "Run unit tests against Java 8"
+
+              dependsOn("test")
+
+              useJUnitPlatform {}
+              maxParallelForks = Runtime.getRuntime().availableProcessors()
+              javaLauncher.set(
+                javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(8)) }
+              )
+            }
+          tasks.named("check") { dependsOn(testWithJava8) }
+        }
+      }
+    }
   }
 
   tasks.withType<Jar>().configureEach {
@@ -98,7 +120,10 @@ allprojects {
     }
   }
 
-  tasks.withType<JavaCompile>().configureEach { options.encoding = "UTF-8" }
+  tasks.withType<JavaCompile>().configureEach {
+    options.encoding = "UTF-8"
+    options.release.set(8)
+  }
 
   tasks.withType<Javadoc>().configureEach {
     val opt = options as CoreJavadocOptions


### PR DESCRIPTION
Although the CEL source code was always compatible with Java 8, the
compiled classes were not, because they were never build with
`--release 8`.

This change adds the changes to Java compilation.

CI didn't catch this issue bug, because the while build was run
with Java 8 and that caused the code to be _built_ again against
Java 8.

So this change also updates the CI workflow to run the tests against
the classes built by Java 11.