### PR TITLE
CI: Run conformance tests only once

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,7 @@ jobs:
           arguments: jmh
 
       - name: Cache Bazel stuff
+        if: ${{ matrix.java-version == '11' }}
         uses: actions/cache@v3
         with:
           path: |
@@ -65,13 +66,14 @@ jobs:
           restore-keys: bazel-
 
       - name: Setup bazel
+        if: ${{ matrix.java-version == '11' }}
         uses: jwlawson/actions-setup-bazel@v1.7.0
         with:
           bazel-version: '3.5.1'
 
       - name: Conformance tests
-        run: |
-          conformance/run-conformance-tests.sh
+        if: ${{ matrix.java-version == '11' }}
+        run: conformance/run-conformance-tests.sh
 
       - uses: codecov/codecov-action@v2
         if: ${{ matrix.java-version == '11' }}


### PR DESCRIPTION
It's just not necessary to run the conformance tests against multiple
different Java versions, because those tests do not hit any code path
in CEL-Java that any way dependends on the Java version.

Running the conformance tests only for one Matrix job also improves
CI runtime, because Bazel's cache depends on the Java version.