### PR TITLE
Release-workflow: no info, no watch-fs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.OSSRH_TOKEN }}
         with:
           cache-read-only: true
-          arguments: --rerun-tasks --info assemble check publishToMavenLocal -x jmh publishToSonatype closeAndReleaseSonatypeStagingRepository -Prelease
+          arguments: --rerun-tasks --no-watch-fs assemble check publishToMavenLocal -x jmh publishToSonatype closeAndReleaseSonatypeStagingRepository -Prelease
 
       - name: Bump to next development version
         run: echo "${NEXT_VERSION}-SNAPSHOT" > version.txt


### PR DESCRIPTION
Removing `--info` and adding `--no-watch-fs`.

No info, because it the "info level" hides the relevant information.

`--no-watch-fs` because it's not necessary, as it's a performance gain
for incremental builds (there's nothing incremental in this WF).