### PR TITLE
Prefix Gradle project names with `cel-`

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -23,12 +23,12 @@ plugins {
 
 dependencies {
   constraints {
-    api(project(":core"))
-    api(project(":generated-antlr", "shadow"))
-    api(project(":generated-pb"))
-    api(project(":conformance"))
-    api(project(":jackson"))
-    api(project(":tools"))
+    api(project(":cel-core"))
+    api(project(":cel-generated-antlr", "shadow"))
+    api(project(":cel-generated-pb"))
+    api(project(":cel-conformance"))
+    api(project(":cel-jackson"))
+    api(project(":cel-tools"))
   }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -140,5 +140,3 @@ publishingHelper {
   nessieRepoName.set("cel-java")
   inceptionYear.set("2021")
 }
-
-extra["maven.artifactId"] = "cel-parent"

--- a/buildSrc/src/main/kotlin/cel-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/cel-conventions.gradle.kts
@@ -105,8 +105,5 @@ plugins.withType<JavaPlugin>().configureEach {
 }
 
 if (project != rootProject) {
-  tasks.withType<Jar>().configureEach {
-    duplicatesStrategy = DuplicatesStrategy.WARN
-    archiveBaseName.set("${rootProject.name}-${project.name}")
-  }
+  tasks.withType<Jar>().configureEach { duplicatesStrategy = DuplicatesStrategy.WARN }
 }

--- a/conformance/build.gradle.kts
+++ b/conformance/build.gradle.kts
@@ -31,9 +31,9 @@ sourceSets.main { java.srcDir(project.buildDir.resolve("generated/source/proto/m
 dependencies {
   implementation(platform(rootProject))
 
-  implementation(project(":core"))
-  implementation(project(":core", "testJar"))
-  implementation(project(":generated-pb", "testJar"))
+  implementation(project(":cel-core"))
+  implementation(project(":cel-core", "testJar"))
+  implementation(project(":cel-generated-pb", "testJar"))
 
   implementation("com.google.protobuf:protobuf-java")
 

--- a/conformance/run-conformance-tests.sh
+++ b/conformance/run-conformance-tests.sh
@@ -19,7 +19,7 @@ wd="$(dirname $0)"
 
 cd "${wd}/.." || exit 1
 
-./gradlew :conformance:shadowJar || exit 1
+./gradlew :cel-conformance:shadowJar || exit 1
 
 server_pid_file="$(realpath ./conformance/conformance-server.pid)"
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -29,15 +29,15 @@ plugins {
 }
 
 dependencies {
-  implementation(project(":generated-antlr", "shadow"))
-  api(project(":generated-pb"))
+  implementation(project(":cel-generated-antlr", "shadow"))
+  api(project(":cel-generated-pb"))
 
   compileOnly(platform(rootProject))
 
   implementation("org.agrona:agrona:${rootProject.extra["versionAgrona"]}")
 
   testImplementation(platform(rootProject))
-  testImplementation(project(":generated-pb", "testJar"))
+  testImplementation(project(":cel-generated-pb", "testJar"))
   testImplementation("org.assertj:assertj-core")
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.jupiter:junit-jupiter-params")

--- a/gradle/dependabot/build.gradle.kts
+++ b/gradle/dependabot/build.gradle.kts
@@ -38,7 +38,7 @@ plugins {
   id("org.caffinitas.gradle.testsummary") version "0.1.1"
   id("org.caffinitas.gradle.testrerun") version "0.1"
   id("org.jetbrains.gradle.plugin.idea-ext") version "1.1.5"
-  id("org.projectnessie.buildsupport.spotless") version "0.1.10"
+  id("org.projectnessie.buildsupport.spotless") version "0.2.0"
   // The above version "includes" the ones below
   //  org.projectnessie.buildsupport.attach-test-jar
   //  org.projectnessie.buildsupport.checkstyle

--- a/jackson/build.gradle.kts
+++ b/jackson/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":core"))
+  api(project(":cel-core"))
 
   compileOnly(platform(rootProject))
   implementation(
@@ -39,7 +39,7 @@ dependencies {
 
   testImplementation(platform(rootProject))
   testAnnotationProcessor(platform(rootProject))
-  testImplementation(project(":tools"))
+  testImplementation(project(":cel-tools"))
   testAnnotationProcessor("org.immutables:value-processor")
   testCompileOnly("org.immutables:value-annotations")
   testImplementation("com.google.code.findbugs:jsr305")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -92,7 +92,7 @@ pluginManagement {
   }
 }
 
-rootProject.name = "cel"
+rootProject.name = "cel-parent"
 
 gradle.beforeProject {
   group = "org.projectnessie.cel"
@@ -107,21 +107,26 @@ gradle.beforeProject {
     }
 }
 
-include("generated-antlr")
+fun celProject(name: String) {
+  include("cel-$name")
+  project(":cel-$name").projectDir = file(name)
+}
 
-include("generated-pb")
+celProject("generated-antlr")
 
-include("core")
+celProject("generated-pb")
 
-include("jackson")
+celProject("core")
 
-include("conformance")
+celProject("jackson")
 
-include("tools")
+celProject("conformance")
 
-include("jacoco")
+celProject("tools")
 
-include("bom")
+celProject("jacoco")
+
+celProject("bom")
 
 if (false) {
   include("gradle:dependabot")

--- a/tools/build.gradle.kts
+++ b/tools/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":core"))
+  api(project(":cel-core"))
 
   testImplementation(platform(rootProject))
   testImplementation("org.assertj:assertj-core")


### PR DESCRIPTION
See removal of 'mavenArtifactId` in https://github.com/projectnessie/gradle-build-plugins/pull/20

Includes change from #220 "Bump org.projectnessie.buildsupport.spotless from 0.1.10 to 0.2.0"