### PR TITLE
Replace incorrect use of getIndex() in EnumValueDescriptor with getNumber()

### DIFF
--- a/core/src/main/java/org/projectnessie/cel/common/types/pb/EnumValueDescription.java
+++ b/core/src/main/java/org/projectnessie/cel/common/types/pb/EnumValueDescription.java
@@ -45,7 +45,7 @@ public final class EnumValueDescription {
 
   /** Value returns the (numeric) value of the enum. */
   public int value() {
-    return desc.getIndex();
+    return desc.getNumber();
   }
 
   @Override

--- a/core/src/test/java/org/projectnessie/cel/common/types/ProviderTest.java
+++ b/core/src/test/java/org/projectnessie/cel/common/types/ProviderTest.java
@@ -69,7 +69,7 @@ import org.projectnessie.cel.common.types.ref.TypeRegistry;
 import org.projectnessie.cel.common.types.ref.Val;
 import org.projectnessie.cel.common.types.traits.Indexer;
 import org.projectnessie.cel.common.types.traits.Lister;
-import org.projectnessie.test.proto3.OutOfOrderEnumOuterClass;
+import org.projectnessie.cel.test.proto3.OutOfOrderEnumOuterClass;
 
 public class ProviderTest {
 
@@ -98,19 +98,26 @@ public class ProviderTest {
 
     // Previously, we checked `getIndex` on the `EnumValueDescriptor`, which is the same as the
     // `ordinal` value on the enum.
-    assertThat(OutOfOrderEnumOuterClass.OutOfOrderEnum.TWO.ordinal())
-        .isEqualTo(OutOfOrderEnumOuterClass.OutOfOrderEnum.TWO.getValueDescriptor().getIndex());
     // Test the case where the protobuf-defined value for the enum differs from the generated Java
     // enum's ordinal() function.
-    assertThat(OutOfOrderEnumOuterClass.OutOfOrderEnum.TWO.getNumber())
-        .isNotEqualTo(OutOfOrderEnumOuterClass.OutOfOrderEnum.TWO.ordinal());
-    assertThat(OutOfOrderEnumOuterClass.OutOfOrderEnum.TWO.getNumber())
-        .isNotEqualTo(OutOfOrderEnumOuterClass.OutOfOrderEnum.TWO.getValueDescriptor().getIndex());
+    assertThat(OutOfOrderEnumOuterClass.OutOfOrderEnum.TWO.ordinal())
+        .isEqualTo(OutOfOrderEnumOuterClass.OutOfOrderEnum.TWO.getValueDescriptor().getIndex())
+        .isNotEqualTo(OutOfOrderEnumOuterClass.OutOfOrderEnum.TWO.getNumber());
     // Check that we correctly get the protobuf-defined number.
-    Val enumVal3 = reg.enumValue("org.projectnessie.test.proto3.OutOfOrderEnum.TWO");
+    Val enumVal3 = reg.enumValue("org.projectnessie.cel.test.proto3.OutOfOrderEnum.TWO");
     assertThat(enumVal3)
         .extracting(Val::intValue)
         .isEqualTo((long) OutOfOrderEnumOuterClass.OutOfOrderEnum.TWO.getNumber());
+
+    // Test also with the case where there's a gap in the enum (FOUR is not defined).
+    assertThat(OutOfOrderEnumOuterClass.OutOfOrderEnum.FIVE.ordinal())
+        .isEqualTo(OutOfOrderEnumOuterClass.OutOfOrderEnum.FIVE.getValueDescriptor().getIndex())
+        .isNotEqualTo(OutOfOrderEnumOuterClass.OutOfOrderEnum.FIVE.getNumber());
+    // Check that we correctly get the protobuf-defined number.
+    Val enumVal4 = reg.enumValue("org.projectnessie.cel.test.proto3.OutOfOrderEnum.FIVE");
+    assertThat(enumVal4)
+        .extracting(Val::intValue)
+        .isEqualTo((long) OutOfOrderEnumOuterClass.OutOfOrderEnum.FIVE.getNumber());
   }
 
   @Test

--- a/core/src/test/java/org/projectnessie/cel/common/types/ProviderTest.java
+++ b/core/src/test/java/org/projectnessie/cel/common/types/ProviderTest.java
@@ -69,6 +69,7 @@ import org.projectnessie.cel.common.types.ref.TypeRegistry;
 import org.projectnessie.cel.common.types.ref.Val;
 import org.projectnessie.cel.common.types.traits.Indexer;
 import org.projectnessie.cel.common.types.traits.Lister;
+import org.projectnessie.test.proto3.OutOfOrderEnumOuterClass;
 
 public class ProviderTest {
 
@@ -87,12 +88,29 @@ public class ProviderTest {
   void typeRegistryEnumValue() {
     ProtoTypeRegistry reg = newEmptyRegistry();
     reg.registerDescriptor(GlobalEnum.getDescriptor().getFile());
+    reg.registerDescriptor(OutOfOrderEnumOuterClass.getDescriptor().getFile());
 
     Val enumVal = reg.enumValue("google.api.expr.test.v1.proto3.GlobalEnum.GOO");
-    assertThat(enumVal).extracting(Val::intValue).isEqualTo((long) GlobalEnum.GOO.ordinal());
+    assertThat(enumVal).extracting(Val::intValue).isEqualTo((long) GlobalEnum.GOO.getNumber());
 
     Val enumVal2 = reg.findIdent("google.api.expr.test.v1.proto3.GlobalEnum.GOO");
     assertThat(enumVal2.equal(enumVal)).isSameAs(True);
+
+    // Previously, we checked `getIndex` on the `EnumValueDescriptor`, which is the same as the
+    // `ordinal` value on the enum.
+    assertThat(OutOfOrderEnumOuterClass.OutOfOrderEnum.TWO.ordinal())
+        .isEqualTo(OutOfOrderEnumOuterClass.OutOfOrderEnum.TWO.getValueDescriptor().getIndex());
+    // Test the case where the protobuf-defined value for the enum differs from the generated Java
+    // enum's ordinal() function.
+    assertThat(OutOfOrderEnumOuterClass.OutOfOrderEnum.TWO.getNumber())
+        .isNotEqualTo(OutOfOrderEnumOuterClass.OutOfOrderEnum.TWO.ordinal());
+    assertThat(OutOfOrderEnumOuterClass.OutOfOrderEnum.TWO.getNumber())
+        .isNotEqualTo(OutOfOrderEnumOuterClass.OutOfOrderEnum.TWO.getValueDescriptor().getIndex());
+    // Check that we correctly get the protobuf-defined number.
+    Val enumVal3 = reg.enumValue("org.projectnessie.test.proto3.OutOfOrderEnum.TWO");
+    assertThat(enumVal3)
+        .extracting(Val::intValue)
+        .isEqualTo((long) OutOfOrderEnumOuterClass.OutOfOrderEnum.TWO.getNumber());
   }
 
   @Test

--- a/generated-pb/src/test/proto/out_of_order_enum.proto
+++ b/generated-pb/src/test/proto/out_of_order_enum.proto
@@ -1,0 +1,7 @@
+package org.projectnessie.test.proto3;
+
+enum OutOfOrderEnum {
+  ZERO = 0;
+  TWO = 2;
+  ONE = 1;
+}

--- a/generated-pb/src/test/proto/out_of_order_enum.proto
+++ b/generated-pb/src/test/proto/out_of_order_enum.proto
@@ -1,7 +1,14 @@
-package org.projectnessie.test.proto3;
+package org.projectnessie.cel.test.proto3;
 
+// Enum intended to provide test values where the ordinal/index of the
+// enum variant differs from the actual enum value.
 enum OutOfOrderEnum {
   ZERO = 0;
+  // TWO is set to have a value of 2, but it's in the 1-indexed position
+  // because it is out of order.
   TWO = 2;
   ONE = 1;
+  // FIVE is set to have a value of 5, but it's in the 3-indexed position
+  // because there is a gap in the sequence of enum values.
+  FIVE = 5;
 }


### PR DESCRIPTION
Fixes #225 

1. [Best practice for protocol buffers](https://errorprone.info/bugpattern/ProtocolBufferOrdinal) is to use `getNumber` rather than `ordinal` on the generated Java enum (which the `EnumValueDescriptor`'s `getIndex` corresponds to
2. The `cel-go` implementation that `cel-java` is based on uses `getNumber`
3. other parts of `cel-java` use `getNumber`

Note: the test update corrects the test to do the right thing, but it doesn't fail in the existing (incorrect) implementation because the test enum has `getNumber() == getIndex()` for all values.