### PR TITLE
Fix publishing

### DIFF
--- a/buildSrc/src/main/kotlin/cel-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/cel-conventions.gradle.kts
@@ -32,7 +32,6 @@ import org.projectnessie.buildtools.publishing.PublishingHelperPlugin
 plugins {
   id("org.projectnessie.buildsupport.jacoco")
   id("org.projectnessie.buildsupport.spotless")
-  `maven-publish`
 }
 
 if (project.name != "conformance" && project.name != "jacoco") {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -19,6 +19,7 @@ import com.google.protobuf.gradle.protoc
 plugins {
   `java-library`
   signing
+  `maven-publish`
   id("com.diffplug.spotless")
   id("com.google.protobuf")
   id("me.champeau.jmh")

--- a/jackson/build.gradle.kts
+++ b/jackson/build.gradle.kts
@@ -16,6 +16,7 @@
 
 plugins {
   `java-library`
+  `maven-publish`
   signing
   id("org.caffinitas.gradle.aggregatetestresults")
   id("org.caffinitas.gradle.testsummary")

--- a/tools/build.gradle.kts
+++ b/tools/build.gradle.kts
@@ -16,6 +16,7 @@
 
 plugins {
   `java-library`
+  `maven-publish`
   signing
   id("org.caffinitas.gradle.aggregatetestresults")
   id("org.caffinitas.gradle.testsummary")


### PR DESCRIPTION
PR #200 broke the CEL release process by accidentally trying to
publish _all_ projects, but some are not meant to be published
(cel-conformance and cel-jacoco). These do now break the release
via sonatype.

Note: the `cel-conventions.gradle.kts` applied `maven-publish` to
all projects, which was the mistake in #200.