### PR TITLE
Allow publishing Gradle build scans from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,12 +66,12 @@ jobs:
         with:
           # Spotless must run in a different invocation, because
           # it has some weird Gradle configuration/variant issue
-          arguments: spotlessCheck
+          arguments: spotlessCheck --scan
 
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: --rerun-tasks assemble ${{ env.ADDITIONAL_GRADLE_OPTS }} check publishToMavenLocal -x jmh -x spotlessCheck
+          arguments: --rerun-tasks assemble ${{ env.ADDITIONAL_GRADLE_OPTS }} check publishToMavenLocal -x jmh -x spotlessCheck --scan
 
       - name: Build tool integrations
         # The buildToolIntegration* tasks require publishToMavenLocal, run it as a separate step,

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,44 @@ pluginManagement {
   }
 }
 
+plugins { id("com.gradle.enterprise") version ("3.12") }
+
+gradleEnterprise {
+  if (System.getenv("CI") != null) {
+    buildScan {
+      termsOfServiceUrl = "https://gradle.com/terms-of-service"
+      termsOfServiceAgree = "yes"
+      // Add some potentially interesting information from the environment
+      listOf(
+          "GITHUB_ACTION_REPOSITORY",
+          "GITHUB_ACTOR",
+          "GITHUB_BASE_REF",
+          "GITHUB_HEAD_REF",
+          "GITHUB_JOB",
+          "GITHUB_REF",
+          "GITHUB_REPOSITORY",
+          "GITHUB_RUN_ID",
+          "GITHUB_RUN_NUMBER",
+          "GITHUB_SHA",
+          "GITHUB_WORKFLOW"
+        )
+        .forEach { e ->
+          val v = System.getenv(e)
+          if (v != null) {
+            value(e, v)
+          }
+        }
+      val ghUrl = System.getenv("GITHUB_SERVER_URL")
+      if (ghUrl != null) {
+        val ghRepo = System.getenv("GITHUB_REPOSITORY")
+        val ghRunId = System.getenv("GITHUB_RUN_ID")
+        link("Summary", "$ghUrl/$ghRepo/actions/runs/$ghRunId")
+        link("PRs", "$ghUrl/$ghRepo/pulls")
+      }
+    }
+  }
+}
+
 rootProject.name = "cel-parent"
 
 gradle.beforeProject {


### PR DESCRIPTION
But not automatically for every build to protect sensitve workflows, like releasw workflows that have access to sensitive secrets. Gradle build scans are available for free (Gradle Enterprise is not required). The scans help identifying build issues, dependency issues, build performance issues. Also interesting: it shows the result of each test of a CI run.

Build scans are not published for every run - especially sensitive workflows (release workflows w/ access to secrets) are not scanned/published.

Links to the build scans are available from the Summary page of the workflow runs.