### PR TITLE
CI: Remove deprecated `::set-output`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,9 +140,9 @@ jobs:
           $(cat ${DIR}/release-log)
           EOF
 
-          echo ::set-output name=NOTES_FILE::${NOTES_FILE}
+          echo "NOTES_FILE=${NOTES_FILE}" >> ${GITHUB_ENV}
 
       - name: Create Release in GitHub
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
-          gh release create ${GIT_TAG} --notes-file ${{ steps.prep_release.outputs.NOTES_FILE }} --title "CEL-Java ${RELEASE_VERSION}"
+          gh release create ${GIT_TAG} --notes-file ${NOTES_FILE} --title "CEL-Java ${RELEASE_VERSION}"


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/