### PR TITLE
CI: Un-bump latest Java from 20 to 19

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        java-version: [11, 17, 20]
+        java-version: [11, 17, 19]
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Gradle 8.0.2 has issues with Java 20 :(

```
FAILURE: Build failed with an exception.

* What went wrong:
Could not open cp_init generic class cache for initialization script '/home/runner/.gradle/init.d/build-result-capture.init.gradle' (/home/runner/.gradle/caches/8.0.2/scripts/81bhe3x4qmzhxltbvjll89pw1).
> BUG! exception in phase 'semantic analysis' in source unit '_BuildScript_' Unsupported class file major version 64
```