### PR TITLE
Expose causing `RuntimeException`s

### DIFF
--- a/core/src/main/java/org/projectnessie/cel/Env.java
+++ b/core/src/main/java/org/projectnessie/cel/Env.java
@@ -201,7 +201,7 @@ public final class Env {
     // The once call will ensure that this value is set or nil for all invocations.
     if (chkErr != null) {
       Errors errs = new Errors(ast.getSource());
-      errs.reportError(NoLocation, "%s", chkErr.toString());
+      errs.reportError(chkErr, NoLocation, "%s", chkErr.toString());
       return new AstIssuesTuple(null, newIssues(errs));
     }
 

--- a/core/src/main/java/org/projectnessie/cel/common/CELError.java
+++ b/core/src/main/java/org/projectnessie/cel/common/CELError.java
@@ -28,10 +28,16 @@ public final class CELError implements Comparable<CELError> {
   // private static final char wideInd = '\uFF3E'; // result of Go's width.Widen("^")
   private final Location location;
   private final String message;
+  private final Exception exception;
 
-  public CELError(Location location, String message) {
+  public CELError(Exception e, Location location, String message) {
+    this.exception = e;
     this.location = location;
     this.message = message;
+  }
+
+  public Exception getException() {
+    return exception;
   }
 
   public Location getLocation() {

--- a/core/src/main/java/org/projectnessie/cel/common/Errors.java
+++ b/core/src/main/java/org/projectnessie/cel/common/Errors.java
@@ -29,7 +29,11 @@ public class Errors {
 
   /** ReportError records an error at a source location. */
   public void reportError(Location l, String format, Object... args) {
-    CELError err = new CELError(l, String.format(format, args));
+    reportError(null, l, format, args);
+  }
+
+  public void reportError(Exception e, Location l, String format, Object... args) {
+    CELError err = new CELError(e, l, String.format(format, args));
     errors.add(err);
   }
 

--- a/core/src/main/java/org/projectnessie/cel/parser/Parser.java
+++ b/core/src/main/java/org/projectnessie/cel/parser/Parser.java
@@ -164,7 +164,7 @@ public final class Parser {
         expr = inner.exprVisit(parser.start());
       }
     } catch (RecoveryLimitError | RecursionError e) {
-      errors.reportError(Location.NoLocation, "%s", e.getMessage());
+      errors.reportError(e, Location.NoLocation, "%s", e.getMessage());
     }
 
     if (errors.hasErrors()) {

--- a/core/src/test/java/org/projectnessie/cel/parser/ParserTest.java
+++ b/core/src/test/java/org/projectnessie/cel/parser/ParserTest.java
@@ -1345,6 +1345,7 @@ class ParserTest {
     assertThat(parseResult.getErrors().getErrors())
         .containsExactly(
             new CELError(
+                null,
                 Location.newLocation(-1, -1),
                 "expression code point size exceeds limit: size: 3, limit 2"));
   }

--- a/tools/src/main/java/org/projectnessie/cel/tools/ScriptCreateException.java
+++ b/tools/src/main/java/org/projectnessie/cel/tools/ScriptCreateException.java
@@ -15,7 +15,9 @@
  */
 package org.projectnessie.cel.tools;
 
+import java.util.Objects;
 import org.projectnessie.cel.Issues;
+import org.projectnessie.cel.common.CELError;
 
 public final class ScriptCreateException extends ScriptException {
 
@@ -24,6 +26,10 @@ public final class ScriptCreateException extends ScriptException {
   public ScriptCreateException(String message, Issues issues) {
     super(String.format("%s: %s", message, issues));
     this.issues = issues;
+    issues.getErrors().stream()
+        .map(CELError::getException)
+        .filter(Objects::nonNull)
+        .forEach(this::addSuppressed);
   }
 
   public Issues getIssues() {


### PR DESCRIPTION
Currently, any `ScriptCreateException` caused by `CELError`s caused by `RuntimeException`s only report the exception type and message, but not the stack trace. This change fixes that issue.