### PR TITLE
Allow function activations to return "absent"

### DIFF
--- a/core/src/main/java/org/projectnessie/cel/interpreter/Activation.java
+++ b/core/src/main/java/org/projectnessie/cel/interpreter/Activation.java
@@ -140,7 +140,14 @@ public interface Activation {
     /** ResolveName implements the Activation interface method. */
     @Override
     public ResolvedValue resolveName(String name) {
-      return ResolvedValue.resolvedValue(provider.apply(name));
+      Object result = provider.apply(name);
+      if (result instanceof ResolvedValue) {
+        return (ResolvedValue) result;
+      } else if (result == null) {
+        return ResolvedValue.ABSENT;
+      } else {
+        return ResolvedValue.resolvedValue(result);
+      }
     }
 
     @Override


### PR DESCRIPTION
#368 introduced a regression that made it impossible for function activations to indicate that they don't have a value for a name. This change retains the old behavior by default of treating `null` as "absent", but also lets functions return a resolved value directly.