### PR TITLE
build: `buildSrc` using Java toolchain

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -34,9 +34,4 @@ dependencies {
   implementation(libs.errorprone.plugin)
 }
 
-java {
-  sourceCompatibility = JavaVersion.VERSION_11
-  targetCompatibility = JavaVersion.VERSION_11
-}
-
-kotlinDslPluginOptions { jvmTarget.set(JavaVersion.VERSION_11.toString()) }
+java { toolchain { languageVersion.set(JavaLanguageVersion.of(11)) } }


### PR DESCRIPTION
Replace deprecated `jvmTarget` with Java toolchain.

See warning:
```
> Configure project :buildSrc
The KotlinDslPluginOptions.jvmTarget property has been deprecated. This is scheduled to be removed in Gradle 9.0. Configure a Java Toolchain instead. Consult the upgrading guide for further information: https://docs.gradle.org/8.1.1/userguide/upgrading_version_7.html#kotlin_dsl_plugin_toolchains
        at Build_gradle$4.execute(build.gradle.kts:48)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```