### PR TITLE
Fix indeterministic hashing for BytesT

### DIFF
--- a/core/src/main/java/org/projectnessie/cel/common/types/BytesT.java
+++ b/core/src/main/java/org/projectnessie/cel/common/types/BytesT.java
@@ -207,7 +207,7 @@ public final class BytesT extends BaseVal implements Adder, Comparer, Sizer {
 
   @Override
   public int hashCode() {
-    int result = super.hashCode();
+    int result = 0;
     result = 31 * result + Arrays.hashCode(b);
     return result;
   }

--- a/core/src/test/java/org/projectnessie/cel/common/types/BytesTest.java
+++ b/core/src/test/java/org/projectnessie/cel/common/types/BytesTest.java
@@ -35,6 +35,7 @@ import com.google.protobuf.Value;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
+import org.projectnessie.cel.common.types.ref.Val;
 
 public class BytesTest {
 
@@ -109,5 +110,12 @@ public class BytesTest {
   @Test
   void bytesSize() {
     assertThat(bytesOf("1234567890").size().equal(intOf(10))).isSameAs(True);
+  }
+
+  @Test
+  void bytesContains() {
+    Val bar1 = bytesOf(ByteString.copyFromUtf8("bar"));
+    Val bar2 = bytesOf(ByteString.copyFromUtf8("bar"));
+    assertThat(bar1.hashCode()).isEqualTo(bar2.hashCode());
   }
 }


### PR DESCRIPTION
I'm looking into different list look up use cases and found an issue with bytes. I looked into it a bit and found that what is happening is that the `BytesT` is calling the `super.hasCode()` which is unintentionally calling a `hashCode()` directly on an array which led to an indeterministic hashed value (it's preferred to use `Arrays.hashCode(b)` instead).

The change here is to change the initial value from calling `super.hashCode()` to just using the value 0. The alternative is to use the value `Arrays.hashCode(b)` if preferred.