### PR TITLE
Introduce `cel-standalone` (no dependencies) artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,16 @@ dependencies {
 }
 ```
 
+## Dependency-free artifact
+
+The `org.projectnessie.cel:cel-standalone` contains everything from CEL-Java and has no dependencies.
+It comes with relocated dependencies.
+
+Using `cel-standalone` is especially useful when your project requires different versions of
+`protobuf-java`.
+
+Use _either_ `cel-tools` _or_ `cel-standalone` - never both!
+
 ## Motivation to have a CEL-Java port
 
 The [Common Expression Language](https://github.com/google/cel-spec/) allows simple computations

--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     api(project(":cel-conformance"))
     api(project(":cel-jackson"))
     api(project(":cel-tools"))
+    api(project(":cel-standalone"))
   }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,9 +48,6 @@ idea-ext = { module = "gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle
 immutables-value-annotations = { module = "org.immutables:value-annotations", version.ref = "immutables" }
 immutables-value-processor = { module = "org.immutables:value-processor", version.ref = "immutables" }
 jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version = "2.16.0" }
-jackson-core = { module = "com.fasterxml.jackson.core:jackson-databind" }
-jackson-dataformat-protobuf = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-protobuf" }
-jackson-dataformat-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml" }
 jacoco-maven-plugin = { module = "org.jacoco:jacoco-maven-plugin", version.ref = "jacoco" }
 jandex-plugin = { module = "com.github.vlsi.gradle:jandex-plugin", version.ref = "jandexPlugin" }
 jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }

--- a/jackson/build.gradle.kts
+++ b/jackson/build.gradle.kts
@@ -28,9 +28,10 @@ dependencies {
   api(project(":cel-core"))
 
   implementation(platform(libs.jackson.bom))
-  implementation(libs.jackson.core)
-  implementation(libs.jackson.dataformat.protobuf)
-  implementation(libs.jackson.dataformat.yaml)
+  implementation("com.fasterxml.jackson.core:jackson-databind")
+  implementation("com.fasterxml.jackson.core:jackson-core")
+  implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-protobuf")
+  implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
 
   testImplementation(project(":cel-tools"))
   testAnnotationProcessor(libs.immutables.value.processor)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -75,6 +75,7 @@ gradle.beforeProject {
       "core" -> "Common-Expression-Language - Java - Core Module"
       "tools" -> "Common-Expression-Language - Script Tools"
       "jackson" -> "Common-Expression-Language - Jackson Type Registry"
+      "standalone" -> "Common-Expression-Language - CEL with relocated protobuf-java"
       else -> name
     }
 }
@@ -95,5 +96,7 @@ celProject("jackson")
 celProject("conformance")
 
 celProject("tools")
+
+celProject("standalone")
 
 celProject("bom")

--- a/standalone/build.gradle.kts
+++ b/standalone/build.gradle.kts
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2023 The Authors of CEL-Java
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
+plugins {
+  `java-library`
+  `maven-publish`
+  signing
+  id("com.github.johnrengelman.shadow")
+  `cel-conventions`
+}
+
+dependencies {
+  api(project(":cel-tools"))
+  api(project(":cel-jackson"))
+  api(project(":cel-generated-antlr", configuration = "shadow"))
+
+  compileOnly(libs.protobuf.java)
+  compileOnly(libs.agrona)
+
+  compileOnly(platform(libs.jackson.bom))
+  compileOnly("com.fasterxml.jackson.core:jackson-databind")
+  compileOnly("com.fasterxml.jackson.core:jackson-core")
+  compileOnly("com.fasterxml.jackson.dataformat:jackson-dataformat-protobuf")
+  compileOnly("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
+}
+
+val shadowJar = tasks.named<ShadowJar>("shadowJar")
+
+shadowJar.configure {
+  relocate("com.google.protobuf", "org.projectnessie.cel.relocated.protobuf")
+  relocate("com.fasterxml.jackson", "org.projectnessie.cel.relocated.jackson")
+  relocate("org.agrona", "org.projectnessie.cel.relocated.agrona")
+  manifest {
+    attributes["Specification-Title"] = "Common-Expression-Language - dependency-free CEL"
+    attributes["Specification-Version"] = libs.protobuf.java.get().version
+  }
+  configurations = listOf(project.configurations.getByName("compileClasspath"))
+  dependencies {
+    include(project(":cel-tools"))
+    include(project(":cel-core"))
+    include(project(":cel-jackson"))
+    include(project(":cel-generated-pb"))
+    include(project(":cel-generated-antlr"))
+
+    include(dependency(libs.protobuf.java.get()))
+    include(dependency("com.fasterxml.jackson.core:jackson-databind"))
+    include(dependency("com.fasterxml.jackson.core:jackson-core"))
+    include(dependency("com.fasterxml.jackson.core:jackson-annotations"))
+    include(dependency("com.fasterxml.jackson.dataformat:jackson-dataformat-protobuf"))
+    include(dependency("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"))
+    include(dependency(libs.agrona.get()))
+  }
+}
+
+tasks.named("compileJava").configure { finalizedBy(shadowJar) }
+
+tasks.named("processResources").configure { finalizedBy(shadowJar) }
+
+tasks.named("jar").configure { dependsOn("processJandexIndex", "shadowJar") }
+
+shadowJar.configure {
+  outputs.cacheIf { false } // do not cache uber/shaded jars
+  archiveClassifier.set("")
+  mergeServiceFiles()
+}
+
+tasks.named<Jar>("jar").configure {
+  dependsOn(shadowJar)
+  archiveClassifier.set("raw")
+}
+
+tasks.withType<ShadowJar>().configureEach { exclude("META-INF/jandex.idx") }


### PR DESCRIPTION
Generated Protobuf code must be used with the exact same Protobuf runtime version, because especially provides no back-/forward compatibility guarantees. This change introduces a new artifact `cel-standalone`, which provides a shadow/uber jar with including relocated classes of the required dependencies. `cel-standalone` should only be used when there are library compatibility issues, but must not be used in combination with other CEL artifacts.