### PR TITLE
cel-standalone: do not include Jackson

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,10 +204,12 @@ dependencies {
 ## Dependency-free artifact
 
 The `org.projectnessie.cel:cel-standalone` contains everything from CEL-Java and has no dependencies.
-It comes with relocated dependencies.
+It comes with relocated protobuf dependencies.
 
 Using `cel-standalone` is especially useful when your project requires different versions of
 `protobuf-java`.
+
+If you need CEL-Java's Jackson functionality, include the Jackson dependencies in your project.
 
 Use _either_ `cel-tools` _or_ `cel-standalone` - never both!
 

--- a/standalone/build.gradle.kts
+++ b/standalone/build.gradle.kts
@@ -31,19 +31,12 @@ dependencies {
 
   compileOnly(libs.protobuf.java)
   compileOnly(libs.agrona)
-
-  compileOnly(platform(libs.jackson.bom))
-  compileOnly("com.fasterxml.jackson.core:jackson-databind")
-  compileOnly("com.fasterxml.jackson.core:jackson-core")
-  compileOnly("com.fasterxml.jackson.dataformat:jackson-dataformat-protobuf")
-  compileOnly("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
 }
 
 val shadowJar = tasks.named<ShadowJar>("shadowJar")
 
 shadowJar.configure {
   relocate("com.google.protobuf", "org.projectnessie.cel.relocated.protobuf")
-  relocate("com.fasterxml.jackson", "org.projectnessie.cel.relocated.jackson")
   relocate("org.agrona", "org.projectnessie.cel.relocated.agrona")
   manifest {
     attributes["Specification-Title"] = "Common-Expression-Language - dependency-free CEL"
@@ -58,11 +51,6 @@ shadowJar.configure {
     include(project(":cel-generated-antlr"))
 
     include(dependency(libs.protobuf.java.get()))
-    include(dependency("com.fasterxml.jackson.core:jackson-databind"))
-    include(dependency("com.fasterxml.jackson.core:jackson-core"))
-    include(dependency("com.fasterxml.jackson.core:jackson-annotations"))
-    include(dependency("com.fasterxml.jackson.dataformat:jackson-dataformat-protobuf"))
-    include(dependency("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"))
     include(dependency(libs.agrona.get()))
   }
 }


### PR DESCRIPTION
Relocating Jackson can cause stack-overflow exception, as seen in [this check run](https://github.com/projectnessie/nessie/actions/runs/6934341817/job/18862247196?pr=7738).