### PR TITLE
Fix protobuf relocation of com.google.rpc classes

### DIFF
--- a/standalone/build.gradle.kts
+++ b/standalone/build.gradle.kts
@@ -36,8 +36,9 @@ dependencies {
 val shadowJar = tasks.named<ShadowJar>("shadowJar")
 
 shadowJar.configure {
-  relocate("com.google.protobuf", "org.projectnessie.cel.relocated.protobuf")
-  relocate("org.agrona", "org.projectnessie.cel.relocated.agrona")
+  // relocate com.google.api/protobuf/rpc classes
+  relocate("com.google", "org.projectnessie.cel.relocated.com.google")
+  relocate("org.agrona", "org.projectnessie.cel.relocated.org.agrona")
   manifest {
     attributes["Specification-Title"] = "Common-Expression-Language - dependency-free CEL"
     attributes["Specification-Version"] = libs.protobuf.java.get().version


### PR DESCRIPTION
in our project (which uses `grpc-java` and `protobuf-java`) after we added a dependency on `cel-standalone` 0.4.3 we started seeing these runtime errors in mostly unrelated tests:
```
java.lang.NoSuchMethodError: 'com.google.rpc.Status$Builder com.google.rpc.Status$Builder.addDetails(com.google.protobuf.Any)'
```

in the debugger it was found that `com.google.rpc.Status` was being loaded from `cel-standalone-0.4.3.jar` and thus incompatible with the "normally loaded" `com.google.protobuf.Any` type.

Since the standalone build tries to relocate protobuf i am guessing these `com.google` classes were unintentionally included:
```
unzip -l ~/.m2/repository/org/projectnessie/cel/cel-standalone/0.4.3/cel-standalone-0.4.3.jar | grep -v projectnessie
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  2023-11-21 16:43   META-INF/
      234  2023-11-21 16:43   META-INF/MANIFEST.MF
        0  2023-11-21 16:43   org/
        0  2023-11-21 16:43   META-INF/maven/
        0  2023-11-21 16:43   META-INF/maven/org.antlr/
        0  2023-11-21 16:43   META-INF/maven/org.antlr/antlr4-runtime/
     3552  2023-09-04 22:10   META-INF/maven/org.antlr/antlr4-runtime/pom.xml
       59  2023-09-04 22:10   META-INF/maven/org.antlr/antlr4-runtime/pom.properties
        0  2023-11-21 16:43   com/
        0  2023-11-21 16:43   com/google/
        0  2023-11-21 16:43   com/google/rpc/
    13252  2023-11-21 16:43   com/google/rpc/HttpHeader.class
(...)
     2589  2023-11-21 16:43   com/google/rpc/Status$1.class
      889  2023-11-21 16:43   com/google/rpc/BadRequestOrBuilder.class
    15910  2023-11-21 16:43   com/google/rpc/HttpRequest.class
    15623  2023-11-21 16:43   com/google/rpc/HttpResponse.class
    13472  2023-11-21 16:43   com/google/rpc/LocalizedMessage.class
     2622  2023-11-21 16:43   com/google/rpc/ErrorInfo$1.class
    22279  2023-11-21 16:43   com/google/rpc/BadRequest$Builder.class
        0  2023-11-21 16:43   com/google/api/
        0  2023-11-21 16:43   com/google/api/expr/
        0  2023-11-21 16:43   com/google/api/expr/v1alpha1/
(...)
      864  2023-11-21 16:43   com/google/api/expr/v1alpha1/Type$AbstractTypeOrBuilder.class
        0  2023-11-21 16:43   google/
        0  2023-11-21 16:43   google/protobuf/
     6154  1985-02-01 00:00   google/protobuf/any.proto
     7728  1985-02-01 00:00   google/protobuf/api.proto
    49985  1985-02-01 00:00   google/protobuf/descriptor.proto
     4892  1985-02-01 00:00   google/protobuf/duration.proto
     2363  1985-02-01 00:00   google/protobuf/empty.proto
     8185  1985-02-01 00:00   google/protobuf/field_mask.proto
     2341  1985-02-01 00:00   google/protobuf/source_context.proto
     3778  1985-02-01 00:00   google/protobuf/struct.proto
     6449  1985-02-01 00:00   google/protobuf/timestamp.proto
     6367  1985-02-01 00:00   google/protobuf/type.proto
     4044  1985-02-01 00:00   google/protobuf/wrappers.proto
```