### PR TITLE
CI: Bazel setup action change

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,12 +94,6 @@ jobs:
           key: bazel-${{ hashFiles('**/.gitmodules') }}
           restore-keys: bazel-
 
-      - name: Setup bazel
-        if: ${{ matrix.java-version == '11' }}
-        uses: jwlawson/actions-setup-bazel@v1.10.1
-        with:
-          bazel-version: '6.4.0'
-
       - name: Conformance tests
         if: ${{ matrix.java-version == '11' }}
         run: conformance/run-conformance-tests.sh

--- a/conformance/run-conformance-tests.sh
+++ b/conformance/run-conformance-tests.sh
@@ -25,6 +25,9 @@ server_pid_file="$(realpath ./conformance/conformance-server.pid)"
 
 cd submodules/cel-spec || exit 1
 
+# Bazel version 6.4.0 works, 7.0.2 does not work with the conformance tests
+export USE_BAZEL_VERSION="6.5.0"
+
 bazel build ... || exit 1
 
 cel_java_skips=(


### PR DESCRIPTION
Force bazelisk to use bazel 6.5.0, because latest 7.0.2 does not work