### PR TITLE
Update GH workflows / Gradle run steps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,29 +61,26 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java-version }}
 
-      - name: Spotless Check
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
+          cache-read-only: ${{ github.event_name != 'push' || github.ref != 'refs/heads/main' }}
+
+      - name: Spotless Check
           # Spotless must run in a different invocation, because
           # it has some weird Gradle configuration/variant issue
-          arguments: spotlessCheck --scan
+        run: ./gradlew spotlessCheck --scan
 
-      - name: Build with Gradle
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: --rerun-tasks assemble ${{ env.ADDITIONAL_GRADLE_OPTS }} check publishToMavenLocal -x jmh -x spotlessCheck --scan
+      - name: Build
+        run: ./gradlew --rerun-tasks assemble ${{ env.ADDITIONAL_GRADLE_OPTS }} check publishToMavenLocal -x jmh -x spotlessCheck --scan
 
       - name: Build tool integrations
         # The buildToolIntegration* tasks require publishToMavenLocal, run it as a separate step,
         # because these tasks intentionally do not depend on the publishToMavenLocal tasks.
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: buildToolIntegrations
+        run: ./gradlew buildToolIntegrations
 
       - name: Microbenchmarks
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: jmh
+        run: ./gradlew jmh
 
       - name: Cache Bazel stuff
         if: ${{ matrix.java-version == '11' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,16 +90,18 @@ jobs:
           git commit -a -m "[release] v${RELEASE_VERSION}"
           git tag -f ${GIT_TAG}
 
-      - name: Publish to Sonatype
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-read-only: true
+
+      - name: Publish to Sonatype
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.OSSRH_ACCESS_ID }}
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.OSSRH_TOKEN }}
-        with:
-          cache-read-only: true
-          arguments: --rerun-tasks --no-watch-fs assemble check publishToMavenLocal -x jmh publishToSonatype closeAndReleaseSonatypeStagingRepository -Prelease
+        run: ./gradlew --rerun-tasks --no-watch-fs assemble check publishToMavenLocal -x jmh publishToSonatype closeAndReleaseSonatypeStagingRepository -Prelease
 
       - name: Bump to next development version
         run: echo "${NEXT_VERSION}-SNAPSHOT" > version.txt


### PR DESCRIPTION
See https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated for details.

Also make the GH cache read-only for everything except pushes to `main`.