### PR TITLE
Remove use of `org.caffinitas.gradle.aggregatetestresults`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,6 @@ import org.jetbrains.gradle.ext.*
 plugins {
   signing
   `maven-publish`
-  alias(libs.plugins.aggregatetestresults)
   alias(libs.plugins.testsummary)
   alias(libs.plugins.testrerun)
   alias(libs.plugins.nexus.publish)

--- a/conformance/build.gradle.kts
+++ b/conformance/build.gradle.kts
@@ -20,7 +20,6 @@ import com.google.protobuf.gradle.ProtobufPlugin
 plugins {
   `java-library`
   id("com.github.johnrengelman.shadow")
-  id("org.caffinitas.gradle.aggregatetestresults")
   id("org.caffinitas.gradle.testsummary")
   id("org.caffinitas.gradle.testrerun")
   `cel-conventions`

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -20,7 +20,6 @@ plugins {
   `maven-publish`
   id("com.diffplug.spotless")
   alias(libs.plugins.jmh)
-  alias(libs.plugins.aggregatetestresults)
   alias(libs.plugins.testsummary)
   alias(libs.plugins.testrerun)
   `cel-conventions`

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,8 +64,6 @@ spotless-plugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", ver
 tomcat-annotations-api = { module = "org.apache.tomcat:annotations-api", version = "6.0.53" }
 
 [plugins]
-aggregatetestresults = { id = "org.caffinitas.gradle.aggregatetestresults", version = "0.1" }
-errorprone = { id = "net.ltgt.errorprone", version = "4.1.0" }
 idea-ext = { id = "org.jetbrains.gradle.plugin.idea-ext", version = "1.1.10" }
 jandex = { id = "com.github.vlsi.jandex", version.ref = "jandexPlugin" }
 jmh = { id = "me.champeau.jmh", version = "0.7.3" }

--- a/jackson/build.gradle.kts
+++ b/jackson/build.gradle.kts
@@ -18,7 +18,6 @@ plugins {
   `java-library`
   `maven-publish`
   signing
-  id("org.caffinitas.gradle.aggregatetestresults")
   id("org.caffinitas.gradle.testsummary")
   id("org.caffinitas.gradle.testrerun")
   `cel-conventions`

--- a/tools/build.gradle.kts
+++ b/tools/build.gradle.kts
@@ -21,7 +21,6 @@ plugins {
   `java-library`
   `maven-publish`
   signing
-  id("org.caffinitas.gradle.aggregatetestresults")
   id("org.caffinitas.gradle.testsummary")
   id("org.caffinitas.gradle.testrerun")
   `cel-conventions`


### PR DESCRIPTION
The plugin's unmaintained and its value is nowadays quiestionable, and it breaks with JUnit 5.12, therefore just removing it.