### PR TITLE
fix(interpreter): propagate unknown/error operands through == and !=

### DIFF
--- a/core/src/main/java/org/projectnessie/cel/interpreter/Interpretable.java
+++ b/core/src/main/java/org/projectnessie/cel/interpreter/Interpretable.java
@@ -396,6 +396,13 @@ public interface Interpretable {
     public Val eval(org.projectnessie.cel.interpreter.Activation ctx) {
       Val lVal = lhs.eval(ctx);
       Val rVal = rhs.eval(ctx);
+      // Early return if any argument to the function is unknown or error.
+      if (isUnknownOrError(lVal)) {
+        return lVal;
+      }
+      if (isUnknownOrError(rVal)) {
+        return rVal;
+      }
       return lVal.equal(rVal);
     }
 
@@ -439,6 +446,13 @@ public interface Interpretable {
     public Val eval(org.projectnessie.cel.interpreter.Activation ctx) {
       Val lVal = lhs.eval(ctx);
       Val rVal = rhs.eval(ctx);
+      // Early return if any argument to the function is unknown or error.
+      if (isUnknownOrError(lVal)) {
+        return lVal;
+      }
+      if (isUnknownOrError(rVal)) {
+        return rVal;
+      }
       Val eqVal = lVal.equal(rVal);
       switch (eqVal.type().typeEnum()) {
         case Err:

--- a/core/src/test/java/org/projectnessie/cel/CELTest.java
+++ b/core/src/test/java/org/projectnessie/cel/CELTest.java
@@ -49,7 +49,6 @@ import static org.projectnessie.cel.ProgramOption.evalOptions;
 import static org.projectnessie.cel.ProgramOption.functions;
 import static org.projectnessie.cel.ProgramOption.globals;
 import static org.projectnessie.cel.Util.mapOf;
-import static org.projectnessie.cel.common.types.BoolT.False;
 import static org.projectnessie.cel.common.types.BoolT.True;
 import static org.projectnessie.cel.common.types.Err.isError;
 import static org.projectnessie.cel.common.types.Err.newErr;
@@ -657,10 +656,10 @@ public class CELTest {
     assertThat(astIss.hasIssues()).isFalse();
     Program prg = e.program(astIss.getAst(), evalOptions(OptTrackState, OptPartialEval));
     EvalResult outDet = prg.eval(unkVars);
-    assertThat(outDet.getVal()).isSameAs(False);
+    assertThat(outDet.getVal()).isInstanceOf(UnknownT.class);
     Ast residual = e.residualAst(astIss.getAst(), outDet.getEvalDetails());
     String expr = astToString(residual);
-    assertThat(expr).isEqualTo("false");
+    assertThat(expr).isEqualTo("request.auth.claims.email == \"wiley@acme.co\"");
   }
 
   @Test

--- a/core/src/test/java/org/projectnessie/cel/interpreter/InterpreterTest.java
+++ b/core/src/test/java/org/projectnessie/cel/interpreter/InterpreterTest.java
@@ -1505,6 +1505,32 @@ class InterpreterTest {
     assertThat(result).isInstanceOf(Err.class);
   }
 
+  @Test
+  void equalityWithUnknownOperandStaysUnknown() {
+    assertThat(evalWithUnknownStringX("x == 'foo'")).isInstanceOf(UnknownT.class);
+    assertThat(evalWithUnknownStringX("x != 'foo'")).isInstanceOf(UnknownT.class);
+    assertThat(evalWithUnknownStringX("false || x == 'foo'")).isInstanceOf(UnknownT.class);
+    assertThat(evalWithUnknownStringX("false && x == 'foo'")).isSameAs(False);
+  }
+
+  private static Val evalWithUnknownStringX(String expr) {
+    Source src = newTextSource(expr);
+    ParseResult parsed = Parser.parseAllMacros(src);
+    assertThat(parsed.hasErrors()).withFailMessage(parsed.getErrors()::toDisplayString).isFalse();
+
+    Container cont = testContainer("test");
+    TypeRegistry reg = newRegistry();
+    CheckerEnv env = newStandardCheckerEnv(cont, reg);
+    env.add(Decls.newVar("x", Decls.String));
+    CheckResult checkResult = Checker.Check(parsed, src, env);
+
+    AttributeFactory attrs = newPartialAttributeFactory(cont, reg, reg);
+    Interpreter interp = newStandardInterpreter(cont, reg, reg, attrs);
+    Interpretable i = interp.newInterpretable(checkResult.getCheckedExpr());
+    Activation vars = newPartialActivation(mapOf(), newAttributePattern("x"));
+    return i.eval(vars);
+  }
+
   static class ConvTestCase {
     final String in;
     Val out;


### PR DESCRIPTION
Using partial evaluate with unknown variables with `==` or `!=` would incorrectly output `true` or `false` as opposed to `unknown`. 

See the issue at https://github.com/projectnessie/cel-java/issues/863. 

For the corrected test, email is unknown, so email == "wiley@acme.co" (and therefore the whole expression) should evaluate to unknown, not false. 
