### PR TITLE
Use declaring enum class for Jackson names

### DIFF
--- a/jackson/src/main/java/org/projectnessie/cel/types/jackson/JacksonEnumValue.java
+++ b/jackson/src/main/java/org/projectnessie/cel/types/jackson/JacksonEnumValue.java
@@ -30,7 +30,7 @@ final class JacksonEnumValue {
   }
 
   static String fullyQualifiedName(Enum<?> value) {
-    return value.getClass().getName().replace('$', '.') + '.' + value.name();
+    return value.getDeclaringClass().getName().replace('$', '.') + '.' + value.name();
   }
 
   String fullyQualifiedName() {

--- a/jackson/src/test/java/org/projectnessie/cel/types/jackson/Jackson2TypeDescriptionTest.java
+++ b/jackson/src/test/java/org/projectnessie/cel/types/jackson/Jackson2TypeDescriptionTest.java
@@ -52,6 +52,7 @@ import org.projectnessie.cel.common.types.pb.Checked;
 import org.projectnessie.cel.common.types.ref.Val;
 import org.projectnessie.cel.types.jackson.types.AnEnum;
 import org.projectnessie.cel.types.jackson.types.CollectionsObject;
+import org.projectnessie.cel.types.jackson.types.EnumWithConstantBody;
 import org.projectnessie.cel.types.jackson.types.InnerType;
 
 class Jackson2TypeDescriptionTest {
@@ -115,6 +116,17 @@ class Jackson2TypeDescriptionTest {
 
     assertThatThrownBy(() -> reg.enumDescription(InnerType.class))
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void enumConstantSpecificClassBodyUsesDeclaringClassName() {
+    JacksonRegistry reg = (JacksonRegistry) newRegistry();
+    reg.enumDescription(EnumWithConstantBody.class);
+
+    assertThat(reg.findIdent(EnumWithConstantBody.class.getName() + ".SPECIAL"))
+        .isEqualTo(intOf(EnumWithConstantBody.SPECIAL.ordinal()));
+    assertThat(reg.nativeToValue(EnumWithConstantBody.SPECIAL))
+        .isEqualTo(intOf(EnumWithConstantBody.SPECIAL.ordinal()));
   }
 
   @Test

--- a/jackson/src/test/java/org/projectnessie/cel/types/jackson/types/EnumWithConstantBody.java
+++ b/jackson/src/test/java/org/projectnessie/cel/types/jackson/types/EnumWithConstantBody.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 The Authors of CEL-Java
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.cel.types.jackson.types;
+
+public enum EnumWithConstantBody {
+  DEFAULT,
+  SPECIAL {
+    @Override
+    public String label() {
+      return "special";
+    }
+  };
+
+  public String label() {
+    return name();
+  }
+}

--- a/jackson3/src/main/java/org/projectnessie/cel/types/jackson3/JacksonEnumValue.java
+++ b/jackson3/src/main/java/org/projectnessie/cel/types/jackson3/JacksonEnumValue.java
@@ -30,7 +30,7 @@ final class JacksonEnumValue {
   }
 
   static String fullyQualifiedName(Enum<?> value) {
-    return value.getClass().getName().replace('$', '.') + '.' + value.name();
+    return value.getDeclaringClass().getName().replace('$', '.') + '.' + value.name();
   }
 
   String fullyQualifiedName() {

--- a/jackson3/src/test/java/org/projectnessie/cel/types/jackson3/Jackson3TypeDescriptionTest.java
+++ b/jackson3/src/test/java/org/projectnessie/cel/types/jackson3/Jackson3TypeDescriptionTest.java
@@ -51,6 +51,7 @@ import org.projectnessie.cel.common.types.pb.Checked;
 import org.projectnessie.cel.common.types.ref.Val;
 import org.projectnessie.cel.types.jackson3.types.AnEnum;
 import org.projectnessie.cel.types.jackson3.types.CollectionsObject;
+import org.projectnessie.cel.types.jackson3.types.EnumWithConstantBody;
 import org.projectnessie.cel.types.jackson3.types.InnerType;
 import tools.jackson.databind.JavaType;
 
@@ -115,6 +116,17 @@ class Jackson3TypeDescriptionTest {
 
     assertThatThrownBy(() -> reg.enumDescription(InnerType.class))
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void enumConstantSpecificClassBodyUsesDeclaringClassName() {
+    Jackson3Registry reg = (Jackson3Registry) newRegistry();
+    reg.enumDescription(EnumWithConstantBody.class);
+
+    assertThat(reg.findIdent(EnumWithConstantBody.class.getName() + ".SPECIAL"))
+        .isEqualTo(intOf(EnumWithConstantBody.SPECIAL.ordinal()));
+    assertThat(reg.nativeToValue(EnumWithConstantBody.SPECIAL))
+        .isEqualTo(intOf(EnumWithConstantBody.SPECIAL.ordinal()));
   }
 
   @Test

--- a/jackson3/src/test/java/org/projectnessie/cel/types/jackson3/types/EnumWithConstantBody.java
+++ b/jackson3/src/test/java/org/projectnessie/cel/types/jackson3/types/EnumWithConstantBody.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 The Authors of CEL-Java
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.cel.types.jackson3.types;
+
+public enum EnumWithConstantBody {
+  DEFAULT,
+  SPECIAL {
+    @Override
+    public String label() {
+      return "special";
+    }
+  };
+
+  public String label() {
+    return name();
+  }
+}


### PR DESCRIPTION
Jackson enum identifiers used the runtime constant class, which is an anonymous subclass for enum constants with class bodies.

Build identifiers from the declaring enum class in both Jackson adapters and cover lookup/native conversion for a constant-specific class body.