### PR TITLE
Cache container candidate name resolution

### DIFF
--- a/core/src/main/java/org/projectnessie/cel/common/containers/Container.java
+++ b/core/src/main/java/org/projectnessie/cel/common/containers/Container.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Container holds a reference to an optional qualified container name and set of aliases.
@@ -37,6 +38,7 @@ public final class Container {
 
   private final String name;
   private final Map<String, String> aliases;
+  private final Map<String, String[]> candidateNameCache = new ConcurrentHashMap<>();
 
   /** NewContainer creates a new Container with the fully-qualified name. */
   public static Container newContainer(ContainerOption... opts) {
@@ -108,6 +110,10 @@ public final class Container {
    * precedence over containerized names.
    */
   public String[] resolveCandidateNames(String name) {
+    return candidateNameCache.computeIfAbsent(name, this::computeCandidateNames).clone();
+  }
+
+  private String[] computeCandidateNames(String name) {
     if (name.startsWith(".")) {
       String qn = name.substring(1);
       String alias = findAlias(qn);

--- a/core/src/test/java/org/projectnessie/cel/common/containers/ContainerTest.java
+++ b/core/src/test/java/org/projectnessie/cel/common/containers/ContainerTest.java
@@ -60,6 +60,16 @@ public class ContainerTest {
   }
 
   @Test
+  void ResolveCandidateNames_ReturnsDefensiveArrayCopy() {
+    Container c = newContainer(name("a.b.c.M.N"));
+    String[] names = c.resolveCandidateNames("R.s");
+    names[0] = "mutated";
+
+    assertThat(c.resolveCandidateNames("R.s"))
+        .containsExactly("a.b.c.M.N.R.s", "a.b.c.M.R.s", "a.b.c.R.s", "a.b.R.s", "a.R.s", "R.s");
+  }
+
+  @Test
   void Abbrevs() {
     Container abbr = defaultContainer.extend(abbrevs("my.alias.R"));
     String[] names = abbr.resolveCandidateNames("R");


### PR DESCRIPTION
Avoid rebuilding candidate-name strings for repeated namespace resolution on the same container. Cache computed candidates per container while returning a defensive array copy to preserve caller isolation.