### PR TITLE
Cache field metadata during checking and planning

### DIFF
--- a/core/src/main/java/org/projectnessie/cel/checker/Checker.java
+++ b/core/src/main/java/org/projectnessie/cel/checker/Checker.java
@@ -69,6 +69,7 @@ public final class Checker {
   private final SourceInfo sourceInfo;
   private final Map<Long, Type> types = new HashMap<>();
   private final Map<Long, Reference> references = new HashMap<>();
+  private final Map<String, FieldType> fieldTypes = new HashMap<>();
 
   private Checker(
       CheckerEnv env,
@@ -643,13 +644,26 @@ public final class Checker {
       return null;
     }
 
-    FieldType ft = env.provider.findFieldType(messageType, fieldName);
+    FieldType ft = findFieldType(messageType, fieldName);
     if (ft != null) {
       return ft;
     }
 
     errors.undefinedField(l, fieldName);
     return null;
+  }
+
+  private FieldType findFieldType(String messageType, String fieldName) {
+    String key = messageType + '\n' + fieldName;
+    FieldType ft = fieldTypes.get(key);
+    if (ft != null) {
+      return ft;
+    }
+    ft = env.provider.findFieldType(messageType, fieldName);
+    if (ft != null) {
+      fieldTypes.put(key, ft);
+    }
+    return ft;
   }
 
   void setType(Expr.Builder e, Type t) {

--- a/core/src/main/java/org/projectnessie/cel/interpreter/InterpretablePlanner.java
+++ b/core/src/main/java/org/projectnessie/cel/interpreter/InterpretablePlanner.java
@@ -126,6 +126,7 @@ public interface InterpretablePlanner {
     private final Container container;
     private final Map<Long, Reference> refMap;
     private final Map<Long, Type> typeMap;
+    private final Map<String, FieldType> fieldTypes = new HashMap<>();
     private final InterpretableDecorator[] decorators;
 
     Planner(
@@ -249,7 +250,7 @@ public interface InterpretablePlanner {
       FieldType fieldType = null;
       Type opType = typeMap.get(sel.getOperand().getId());
       if (opType != null && !opType.getMessageType().isEmpty()) {
-        FieldType ft = provider.findFieldType(opType.getMessageType(), sel.getField());
+        FieldType ft = findFieldType(opType.getMessageType(), sel.getField());
         if (ft != null && ft.isSet != null && ft.getFrom != null) {
           fieldType = ft;
         }
@@ -273,7 +274,11 @@ public interface InterpretablePlanner {
         return new EvalTestOnly(expr.getId(), op, stringOf(sel.getField()), fieldType);
       }
       // Build a qualifier.
-      Qualifier qual = attrFactory.newQualifier(opType, expr.getId(), sel.getField());
+      Qualifier qual =
+          fieldType != null
+              ? new AttributeFactory.FieldQualifier(
+                  expr.getId(), sel.getField(), fieldType, adapter)
+              : attrFactory.newQualifier(opType, expr.getId(), sel.getField());
       if (qual == null) {
         return null;
       }
@@ -290,6 +295,19 @@ public interface InterpretablePlanner {
       }
       relAttr.addQualifier(qual);
       return relAttr;
+    }
+
+    private FieldType findFieldType(String messageType, String fieldName) {
+      String key = messageType + '\n' + fieldName;
+      FieldType ft = fieldTypes.get(key);
+      if (ft != null) {
+        return ft;
+      }
+      ft = provider.findFieldType(messageType, fieldName);
+      if (ft != null) {
+        fieldTypes.put(key, ft);
+      }
+      return ft;
     }
 
     /**


### PR DESCRIPTION
Avoid repeated provider field metadata lookups within a checker or planner instance. Reuse checked select field metadata when constructing field qualifiers instead of immediately querying the provider again.