### PR TITLE
Reuse default protobuf registry setup

### DIFF
--- a/core/src/main/java/org/projectnessie/cel/common/types/pb/ProtoTypeRegistry.java
+++ b/core/src/main/java/org/projectnessie/cel/common/types/pb/ProtoTypeRegistry.java
@@ -84,6 +84,8 @@ import org.projectnessie.cel.common.types.ref.TypeRegistry;
 import org.projectnessie.cel.common.types.ref.Val;
 
 public final class ProtoTypeRegistry implements TypeRegistry {
+  private static final ProtoTypeRegistry DEFAULT_REGISTRY = newDefaultRegistry();
+
   private final Map<String, org.projectnessie.cel.common.types.ref.Type> revTypeMap;
   private final Db pbdb;
 
@@ -99,6 +101,14 @@ public final class ProtoTypeRegistry implements TypeRegistry {
    * FileDescriptor.
    */
   public static ProtoTypeRegistry newRegistry(Message... types) {
+    ProtoTypeRegistry p = DEFAULT_REGISTRY.copy();
+    for (Message msgType : types) {
+      p.registerMessage(msgType);
+    }
+    return p;
+  }
+
+  private static ProtoTypeRegistry newDefaultRegistry() {
     ProtoTypeRegistry p = new ProtoTypeRegistry(new HashMap<>(), newDb());
     p.registerType(
         BoolType,
@@ -143,9 +153,6 @@ public final class ProtoTypeRegistry implements TypeRegistry {
     // This block ensures that the well-known protobuf types are registered by default.
     for (FileDescription fd : p.pbdb.fileDescriptions()) {
       p.registerAllTypes(fd);
-    }
-    for (Message msgType : types) {
-      p.registerMessage(msgType);
     }
     return p;
   }

--- a/core/src/test/java/org/projectnessie/cel/common/types/ProviderTest.java
+++ b/core/src/test/java/org/projectnessie/cel/common/types/ProviderTest.java
@@ -85,6 +85,21 @@ public class ProviderTest {
   }
 
   @Test
+  void defaultTypeRegistriesRemainIndependent() {
+    ProtoTypeRegistry reg = newRegistry();
+    ProtoTypeRegistry reg2 = newRegistry();
+    String typeName = TestAllTypes.getDefaultInstance().getDescriptorForType().getFullName();
+
+    assertThat(reg.findType(typeName)).isNull();
+    assertThat(reg2.findType(typeName)).isNull();
+
+    reg.registerMessage(TestAllTypes.getDefaultInstance());
+
+    assertThat(reg.findType(typeName)).isNotNull();
+    assertThat(reg2.findType(typeName)).isNull();
+  }
+
+  @Test
   void typeRegistryEnumValue() {
     ProtoTypeRegistry reg = newEmptyRegistry();
     reg.registerDescriptor(GlobalEnum.getDescriptor().getFile());


### PR DESCRIPTION
Build the default protobuf registry once and create new default registries by copying that prepared baseline.

This avoids repeating scalar and well-known descriptor registration while preserving per-registry mutation isolation.