### PR TITLE
Derive Jackson enum values from enum classes

### DIFF
--- a/jackson/src/main/java/org/projectnessie/cel/types/jackson/JacksonEnumDescription.java
+++ b/jackson/src/main/java/org/projectnessie/cel/types/jackson/JacksonEnumDescription.java
@@ -16,8 +16,9 @@
 package org.projectnessie.cel.types.jackson;
 
 import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ser.std.EnumSerializer;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.projectnessie.cel.common.types.pb.Checked;
 
@@ -27,9 +28,12 @@ final class JacksonEnumDescription {
   private final com.google.api.expr.v1alpha1.Type pbType;
   private final List<Enum<?>> enumValues;
 
-  JacksonEnumDescription(JavaType javaType, EnumSerializer ser) {
+  JacksonEnumDescription(JavaType javaType) {
     this.name = javaType.getRawClass().getName().replace('$', '.');
-    this.enumValues = ser.getEnumValues().enums();
+    this.enumValues =
+        Arrays.stream(javaType.getRawClass().getEnumConstants())
+            .map(enumValue -> (Enum<?>) enumValue)
+            .collect(Collectors.toList());
     this.pbType = Checked.checkedInt;
   }
 

--- a/jackson/src/main/java/org/projectnessie/cel/types/jackson/JacksonRegistry.java
+++ b/jackson/src/main/java/org/projectnessie/cel/types/jackson/JacksonRegistry.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.EnumSerializer;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import java.util.HashMap;
 import java.util.Map;
@@ -162,19 +161,14 @@ public final class JacksonRegistry implements TypeRegistry {
   }
 
   private JacksonEnumDescription computeEnumDescription(Class<?> clazz) {
-    try {
-      JsonSerializer<?> ser = serializationProvider.findValueSerializer(clazz);
-      JavaType javaType = typeFactory.constructType(clazz);
+    JavaType javaType = typeFactory.constructType(clazz);
 
-      JacksonEnumDescription enumDesc = new JacksonEnumDescription(javaType, (EnumSerializer) ser);
-      enumMap.put(clazz, enumDesc);
+    JacksonEnumDescription enumDesc = new JacksonEnumDescription(javaType);
+    enumMap.put(clazz, enumDesc);
 
-      enumDesc.buildValues().forEach(v -> enumValues.put(v.fullyQualifiedName(), v));
+    enumDesc.buildValues().forEach(v -> enumValues.put(v.fullyQualifiedName(), v));
 
-      return enumDesc;
-    } catch (JsonMappingException e) {
-      throw new RuntimeException(e);
-    }
+    return enumDesc;
   }
 
   JacksonTypeDescription typeDescription(Class<?> clazz) {

--- a/jackson/src/test/java/org/projectnessie/cel/types/jackson/Jackson2TypeDescriptionTest.java
+++ b/jackson/src/test/java/org/projectnessie/cel/types/jackson/Jackson2TypeDescriptionTest.java
@@ -52,6 +52,7 @@ import org.projectnessie.cel.common.types.pb.Checked;
 import org.projectnessie.cel.common.types.ref.Val;
 import org.projectnessie.cel.types.jackson.types.AnEnum;
 import org.projectnessie.cel.types.jackson.types.CollectionsObject;
+import org.projectnessie.cel.types.jackson.types.CustomSerializedEnum;
 import org.projectnessie.cel.types.jackson.types.EnumWithConstantBody;
 import org.projectnessie.cel.types.jackson.types.InnerType;
 
@@ -127,6 +128,17 @@ class Jackson2TypeDescriptionTest {
         .isEqualTo(intOf(EnumWithConstantBody.SPECIAL.ordinal()));
     assertThat(reg.nativeToValue(EnumWithConstantBody.SPECIAL))
         .isEqualTo(intOf(EnumWithConstantBody.SPECIAL.ordinal()));
+  }
+
+  @Test
+  void customSerializedEnumRegistrationUsesEnumConstants() {
+    JacksonRegistry reg = (JacksonRegistry) newRegistry();
+    reg.enumDescription(CustomSerializedEnum.class);
+
+    assertThat(reg.findIdent(CustomSerializedEnum.class.getName() + ".TWO"))
+        .isEqualTo(intOf(CustomSerializedEnum.TWO.ordinal()));
+    assertThat(reg.nativeToValue(CustomSerializedEnum.TWO))
+        .isEqualTo(intOf(CustomSerializedEnum.TWO.ordinal()));
   }
 
   @Test

--- a/jackson/src/test/java/org/projectnessie/cel/types/jackson/types/CustomSerializedEnum.java
+++ b/jackson/src/test/java/org/projectnessie/cel/types/jackson/types/CustomSerializedEnum.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 The Authors of CEL-Java
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.cel.types.jackson.types;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.io.IOException;
+
+@JsonSerialize(using = CustomSerializedEnum.Serializer.class)
+public enum CustomSerializedEnum {
+  ONE,
+  TWO;
+
+  public static final class Serializer extends JsonSerializer<CustomSerializedEnum> {
+    @Override
+    public void serialize(
+        CustomSerializedEnum value, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
+      gen.writeString(value.name());
+    }
+  }
+}


### PR DESCRIPTION
Jackson2 enum registration depended on the selected Jackson serializer and could fail when annotations selected a custom serializer.

Derive enum values directly from the raw enum class, matching the Jackson3 path, and cover a custom-serialized enum.