### PR TITLE
Isolate Jackson registry copies

### DIFF
--- a/jackson/src/main/java/org/projectnessie/cel/types/jackson/JacksonRegistry.java
+++ b/jackson/src/main/java/org/projectnessie/cel/types/jackson/JacksonRegistry.java
@@ -60,7 +60,10 @@ public final class JacksonRegistry implements TypeRegistry {
 
   @Override
   public TypeRegistry copy() {
-    return this;
+    JacksonRegistry copy = new JacksonRegistry();
+    knownTypes.keySet().forEach(copy::typeDescription);
+    enumMap.keySet().forEach(copy::enumDescription);
+    return copy;
   }
 
   @Override

--- a/jackson/src/test/java/org/projectnessie/cel/types/jackson/Jackson2RegistryTest.java
+++ b/jackson/src/test/java/org/projectnessie/cel/types/jackson/Jackson2RegistryTest.java
@@ -36,6 +36,8 @@ import org.projectnessie.cel.common.types.ObjectT;
 import org.projectnessie.cel.common.types.ref.TypeEnum;
 import org.projectnessie.cel.common.types.ref.TypeRegistry;
 import org.projectnessie.cel.common.types.ref.Val;
+import org.projectnessie.cel.types.jackson.types.AnEnum;
+import org.projectnessie.cel.types.jackson.types.CollectionsObject;
 import org.projectnessie.cel.types.jackson.types.MetaTest;
 import org.projectnessie.cel.types.jackson.types.RefVariantB;
 
@@ -169,8 +171,24 @@ class Jackson2RegistryTest {
 
   @Test
   void copy() {
-    TypeRegistry reg = JacksonRegistry.newRegistry();
-    assertThat(reg).extracting(TypeRegistry::copy).isSameAs(reg);
+    JacksonRegistry reg = (JacksonRegistry) JacksonRegistry.newRegistry();
+    reg.register(CollectionsObject.class);
+    reg.enumDescription(AnEnum.class);
+
+    JacksonRegistry copy = (JacksonRegistry) reg.copy();
+    assertThat(copy).isNotSameAs(reg);
+    assertThat(copy.findType(CollectionsObject.class.getName())).isNotNull();
+    assertThat(copy.findIdent(AnEnum.class.getName() + "." + AnEnum.ENUM_VALUE_2.name()))
+        .isNotNull();
+
+    copy.register(MetaTest.class);
+    assertThat(copy.findType(MetaTest.class.getName())).isNotNull();
+    assertThat(reg.findType(MetaTest.class.getName())).isNull();
+
+    RefVariantB refVariantB = RefVariantB.of("main", "cafebabe123412341234123412341234");
+    reg.nativeToValue(refVariantB);
+    assertThat(reg.findType(refVariantB.getClass().getName())).isNotNull();
+    assertThat(copy.findType(refVariantB.getClass().getName())).isNull();
   }
 
   @Test

--- a/jackson3/src/main/java/org/projectnessie/cel/types/jackson3/Jackson3Registry.java
+++ b/jackson3/src/main/java/org/projectnessie/cel/types/jackson3/Jackson3Registry.java
@@ -71,7 +71,10 @@ public final class Jackson3Registry implements TypeRegistry {
 
   @Override
   public TypeRegistry copy() {
-    return this;
+    Jackson3Registry copy = new Jackson3Registry();
+    knownTypes.keySet().forEach(copy::typeDescription);
+    enumMap.keySet().forEach(copy::enumDescription);
+    return copy;
   }
 
   @Override

--- a/jackson3/src/test/java/org/projectnessie/cel/types/jackson3/Jackson3RegistryTest.java
+++ b/jackson3/src/test/java/org/projectnessie/cel/types/jackson3/Jackson3RegistryTest.java
@@ -36,6 +36,8 @@ import org.projectnessie.cel.common.types.ObjectT;
 import org.projectnessie.cel.common.types.ref.TypeEnum;
 import org.projectnessie.cel.common.types.ref.TypeRegistry;
 import org.projectnessie.cel.common.types.ref.Val;
+import org.projectnessie.cel.types.jackson3.types.AnEnum;
+import org.projectnessie.cel.types.jackson3.types.CollectionsObject;
 import org.projectnessie.cel.types.jackson3.types.MetaTest;
 import org.projectnessie.cel.types.jackson3.types.RefVariantB;
 
@@ -169,8 +171,24 @@ class Jackson3RegistryTest {
 
   @Test
   void copy() {
-    TypeRegistry reg = Jackson3Registry.newRegistry();
-    assertThat(reg).extracting(TypeRegistry::copy).isSameAs(reg);
+    Jackson3Registry reg = (Jackson3Registry) Jackson3Registry.newRegistry();
+    reg.register(CollectionsObject.class);
+    reg.enumDescription(AnEnum.class);
+
+    Jackson3Registry copy = (Jackson3Registry) reg.copy();
+    assertThat(copy).isNotSameAs(reg);
+    assertThat(copy.findType(CollectionsObject.class.getName())).isNotNull();
+    assertThat(copy.findIdent(AnEnum.class.getName() + "." + AnEnum.ENUM_VALUE_2.name()))
+        .isNotNull();
+
+    copy.register(MetaTest.class);
+    assertThat(copy.findType(MetaTest.class.getName())).isNotNull();
+    assertThat(reg.findType(MetaTest.class.getName())).isNull();
+
+    RefVariantB refVariantB = RefVariantB.of("main", "cafebabe123412341234123412341234");
+    reg.nativeToValue(refVariantB);
+    assertThat(reg.findType(refVariantB.getClass().getName())).isNotNull();
+    assertThat(copy.findType(refVariantB.getClass().getName())).isNull();
   }
 
   @Test


### PR DESCRIPTION
Jackson registry copy() returned the same mutable registry instance, so Env.extend() could share lazy type and enum registrations between parent and child environments.

Create a fresh Jackson registry copy and rebuild the currently known type and enum descriptions into it, with tests covering preserved registrations and isolation of later explicit and lazy registrations.