### PR TITLE
Improve interpreter lookup paths

### DIFF
--- a/core/src/main/java/org/projectnessie/cel/common/types/pb/ProtoTypeRegistry.java
+++ b/core/src/main/java/org/projectnessie/cel/common/types/pb/ProtoTypeRegistry.java
@@ -78,6 +78,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.projectnessie.cel.common.types.TypeT;
 import org.projectnessie.cel.common.types.ref.FieldType;
 import org.projectnessie.cel.common.types.ref.TypeRegistry;
@@ -87,11 +88,13 @@ public final class ProtoTypeRegistry implements TypeRegistry {
   private static final ProtoTypeRegistry DEFAULT_REGISTRY = newDefaultRegistry();
 
   private final Map<String, org.projectnessie.cel.common.types.ref.Type> revTypeMap;
+  private final Map<String, FieldType> fieldTypeCache;
   private final Db pbdb;
 
   private ProtoTypeRegistry(
       Map<String, org.projectnessie.cel.common.types.ref.Type> revTypeMap, Db pbdb) {
     this.revTypeMap = revTypeMap;
+    this.fieldTypeCache = new ConcurrentHashMap<>();
     this.pbdb = pbdb;
   }
 
@@ -197,6 +200,11 @@ public final class ProtoTypeRegistry implements TypeRegistry {
 
   @Override
   public FieldType findFieldType(String messageType, String fieldName) {
+    String cacheKey = messageType + '\n' + fieldName;
+    return fieldTypeCache.computeIfAbsent(cacheKey, key -> loadFieldType(messageType, fieldName));
+  }
+
+  private FieldType loadFieldType(String messageType, String fieldName) {
     PbTypeDescription msgType = pbdb.describeType(messageType);
     if (msgType == null) {
       return null;

--- a/core/src/main/java/org/projectnessie/cel/interpreter/Activation.java
+++ b/core/src/main/java/org/projectnessie/cel/interpreter/Activation.java
@@ -101,12 +101,11 @@ public interface Activation {
     /** ResolveName implements the Activation interface method. */
     @Override
     public ResolvedValue resolveName(String name) {
-      if (!bindings.containsKey(name)) {
-        return ResolvedValue.ABSENT;
-      }
-
       Object obj = bindings.get(name);
       if (obj == null) {
+        if (!bindings.containsKey(name)) {
+          return ResolvedValue.ABSENT;
+        }
         return ResolvedValue.NULL_VALUE;
       }
 

--- a/core/src/main/java/org/projectnessie/cel/interpreter/InterpretablePlanner.java
+++ b/core/src/main/java/org/projectnessie/cel/interpreter/InterpretablePlanner.java
@@ -352,7 +352,7 @@ public interface InterpretablePlanner {
       // Otherwise, generate Interpretable calls specialized by argument count.
       // Try to find the specific function by overload id.
       Overload fnDef = null;
-      if (resolvedFunc.overloadId != null && resolvedFunc.overloadId.isEmpty()) {
+      if (resolvedFunc.overloadId != null && !resolvedFunc.overloadId.isEmpty()) {
         fnDef = disp.findOverload(resolvedFunc.overloadId);
       }
       // If the overload id couldn't resolve the function, try the simple function name.

--- a/core/src/test/java/org/projectnessie/cel/CELTest.java
+++ b/core/src/test/java/org/projectnessie/cel/CELTest.java
@@ -285,6 +285,31 @@ public class CELTest {
   }
 
   @Test
+  void ProgramUsesCheckedOverloadIdForCustomFunctionDispatch() {
+    Env env =
+        newEnv(
+            declarations(
+                Decls.newVar("value", Decls.Int),
+                Decls.newFunction(
+                    "is_even",
+                    Decls.newOverload("is_even_int", singletonList(Decls.Int), Decls.Bool))));
+
+    AstIssuesTuple astIss = env.compile("is_even(value)");
+    assertThat(astIss.hasIssues()).isFalse();
+
+    Program program =
+        env.program(
+            astIss.getAst(),
+            functions(
+                Overload.unary(
+                    "is_even_int",
+                    value -> boolOf(((Number) value.value()).longValue() % 2 == 0))));
+
+    assertThat(program.eval(mapOf("value", 42L)).getVal()).isSameAs(True);
+    assertThat(program.eval(mapOf("value", 41L)).getVal()).isSameAs(False);
+  }
+
+  @Test
   void HomogeneousAggregateLiterals() {
     Env e =
         newCustomEnv(

--- a/core/src/test/java/org/projectnessie/cel/interpreter/ActivationTest.java
+++ b/core/src/test/java/org/projectnessie/cel/interpreter/ActivationTest.java
@@ -54,6 +54,16 @@ public class ActivationTest {
   }
 
   @Test
+  void resolveNullAndAbsentFromMapActivation() {
+    Map<String, Object> map = new HashMap<>();
+    map.put("nullValue", null);
+    Activation activation = newActivation(map);
+
+    assertThat(activation.resolveName("nullValue")).isSameAs(ResolvedValue.NULL_VALUE);
+    assertThat(activation.resolveName("absent")).isSameAs(ResolvedValue.ABSENT);
+  }
+
+  @Test
   void resolveLazy() {
     AtomicReference<Val> v = new AtomicReference<>();
     Supplier<Val> now =


### PR DESCRIPTION
Cache protobuf field metadata lookups per registry and avoid duplicate allocation under concurrent access. Reduce map activation lookups for non-null bindings and use checked overload IDs for custom function dispatch.