### PR TITLE
Plan checked ASTs without wrapper conversion

### DIFF
--- a/core/src/main/java/org/projectnessie/cel/CEL.java
+++ b/core/src/main/java/org/projectnessie/cel/CEL.java
@@ -153,8 +153,7 @@ public final class CEL {
     }
     // When the AST has been checked it contains metadata that can be used to speed up program
     // execution.
-    CheckedExpr checked = astToCheckedExpr(ast);
-    p.interpretable = p.interpreter.newInterpretable(checked, decs);
+    p.interpretable = p.interpreter.newInterpretable(ast.getExpr(), ast.refMap, ast.typeMap, decs);
 
     return p;
   }

--- a/core/src/main/java/org/projectnessie/cel/interpreter/InterpretablePlanner.java
+++ b/core/src/main/java/org/projectnessie/cel/interpreter/InterpretablePlanner.java
@@ -102,6 +102,22 @@ public interface InterpretablePlanner {
   }
 
   /**
+   * newPlanner creates an interpretablePlanner from checked expression metadata without requiring a
+   * CheckedExpr wrapper.
+   */
+  static InterpretablePlanner newPlanner(
+      Dispatcher disp,
+      TypeProvider provider,
+      TypeAdapter adapter,
+      AttributeFactory attrFactory,
+      Container cont,
+      Map<Long, Reference> refMap,
+      Map<Long, Type> typeMap,
+      InterpretableDecorator... decorators) {
+    return new Planner(disp, provider, adapter, attrFactory, cont, refMap, typeMap, decorators);
+  }
+
+  /**
    * newUncheckedPlanner creates an interpretablePlanner which references a Dispatcher,
    * TypeProvider, TypeAdapter, and Container to resolve functions and types at plan time.
    * Namespaces present in Select expressions are resolved lazily at evaluation time.

--- a/core/src/main/java/org/projectnessie/cel/interpreter/Interpreter.java
+++ b/core/src/main/java/org/projectnessie/cel/interpreter/Interpreter.java
@@ -24,6 +24,9 @@ import static org.projectnessie.cel.interpreter.InterpretablePlanner.newUnchecke
 
 import com.google.api.expr.v1alpha1.CheckedExpr;
 import com.google.api.expr.v1alpha1.Expr;
+import com.google.api.expr.v1alpha1.Reference;
+import com.google.api.expr.v1alpha1.Type;
+import java.util.Map;
 import org.projectnessie.cel.common.containers.Container;
 import org.projectnessie.cel.common.types.ref.TypeAdapter;
 import org.projectnessie.cel.common.types.ref.TypeProvider;
@@ -36,6 +39,24 @@ public interface Interpreter {
    * InterpretableDecorator values.
    */
   Interpretable newInterpretable(CheckedExpr checked, InterpretableDecorator... decorators);
+
+  /**
+   * NewInterpretable creates an Interpretable from a checked expression and its metadata without
+   * requiring a CheckedExpr wrapper.
+   */
+  default Interpretable newInterpretable(
+      Expr expr,
+      Map<Long, Reference> refMap,
+      Map<Long, Type> typeMap,
+      InterpretableDecorator... decorators) {
+    CheckedExpr checked =
+        CheckedExpr.newBuilder()
+            .setExpr(expr)
+            .putAllReferenceMap(refMap)
+            .putAllTypeMap(typeMap)
+            .build();
+    return newInterpretable(checked, decorators);
+  }
 
   /**
    * NewUncheckedInterpretable returns an Interpretable from a parsed expression and an optional
@@ -126,6 +147,19 @@ public interface Interpreter {
       InterpretablePlanner p =
           newPlanner(dispatcher, provider, adapter, attrFactory, container, checked, decorators);
       return p.plan(checked.getExpr());
+    }
+
+    /** NewIntepretable implements the Interpreter interface method. */
+    @Override
+    public Interpretable newInterpretable(
+        Expr expr,
+        Map<Long, Reference> refMap,
+        Map<Long, Type> typeMap,
+        InterpretableDecorator... decorators) {
+      InterpretablePlanner p =
+          newPlanner(
+              dispatcher, provider, adapter, attrFactory, container, refMap, typeMap, decorators);
+      return p.plan(expr);
     }
 
     /** NewUncheckedIntepretable implements the Interpreter interface method. */

--- a/core/src/main/java/org/projectnessie/cel/interpreter/Interpreter.java
+++ b/core/src/main/java/org/projectnessie/cel/interpreter/Interpreter.java
@@ -34,15 +34,12 @@ import org.projectnessie.cel.interpreter.functions.Overload;
 
 /** Interpreter generates a new Interpretable from a checked or unchecked expression. */
 public interface Interpreter {
-  /**
-   * NewInterpretable creates an Interpretable from a checked expression and an optional list of
-   * InterpretableDecorator values.
-   */
+  /** Creates an {@link Interpretable} from a checked expression and optional decorators. */
   Interpretable newInterpretable(CheckedExpr checked, InterpretableDecorator... decorators);
 
   /**
-   * NewInterpretable creates an Interpretable from a checked expression and its metadata without
-   * requiring a CheckedExpr wrapper.
+   * Creates an {@link Interpretable} directly from an expression and its checked metadata without
+   * constructing a {@link CheckedExpr} wrapper.
    */
   default Interpretable newInterpretable(
       Expr expr,
@@ -58,10 +55,7 @@ public interface Interpreter {
     return newInterpretable(checked, decorators);
   }
 
-  /**
-   * NewUncheckedInterpretable returns an Interpretable from a parsed expression and an optional
-   * list of InterpretableDecorator values.
-   */
+  /** Creates an {@link Interpretable} from a parsed expression and optional decorators. */
   Interpretable newUncheckedInterpretable(Expr expr, InterpretableDecorator... decorators);
 
   /**
@@ -140,7 +134,6 @@ public interface Interpreter {
       this.attrFactory = attrFactory;
     }
 
-    /** NewIntepretable implements the Interpreter interface method. */
     @Override
     public Interpretable newInterpretable(
         CheckedExpr checked, InterpretableDecorator... decorators) {
@@ -149,7 +142,6 @@ public interface Interpreter {
       return p.plan(checked.getExpr());
     }
 
-    /** NewIntepretable implements the Interpreter interface method. */
     @Override
     public Interpretable newInterpretable(
         Expr expr,
@@ -162,7 +154,6 @@ public interface Interpreter {
       return p.plan(expr);
     }
 
-    /** NewUncheckedIntepretable implements the Interpreter interface method. */
     @Override
     public Interpretable newUncheckedInterpretable(
         Expr expr, InterpretableDecorator... decorators) {


### PR DESCRIPTION
Pass checked expression metadata directly into the interpreter planner during program creation.

This avoids constructing a temporary CheckedExpr on the hot compile-to-program path while preserving the existing checked-expression API.