### PR TITLE
Make Jackson registry caches concurrent

### DIFF
--- a/jackson/src/main/java/org/projectnessie/cel/types/jackson/JacksonRegistry.java
+++ b/jackson/src/main/java/org/projectnessie/cel/types/jackson/JacksonRegistry.java
@@ -158,20 +158,11 @@ public final class JacksonRegistry implements TypeRegistry {
     if (ed != null) {
       return ed;
     }
-    ed = computeEnumDescription(clazz);
+    JavaType javaType = typeFactory.constructType(clazz);
+    ed = new JacksonEnumDescription(javaType);
+    ed.buildValues().forEach(v -> enumValues.put(v.fullyQualifiedName(), v));
     enumMap.put(clazz, ed);
     return ed;
-  }
-
-  private JacksonEnumDescription computeEnumDescription(Class<?> clazz) {
-    JavaType javaType = typeFactory.constructType(clazz);
-
-    JacksonEnumDescription enumDesc = new JacksonEnumDescription(javaType);
-    enumMap.put(clazz, enumDesc);
-
-    enumDesc.buildValues().forEach(v -> enumValues.put(v.fullyQualifiedName(), v));
-
-    return enumDesc;
   }
 
   synchronized JacksonTypeDescription typeDescription(Class<?> clazz) {

--- a/jackson/src/main/java/org/projectnessie/cel/types/jackson/JacksonRegistry.java
+++ b/jackson/src/main/java/org/projectnessie/cel/types/jackson/JacksonRegistry.java
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.type.TypeFactory;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.projectnessie.cel.common.types.ref.FieldType;
 import org.projectnessie.cel.common.types.ref.Type;
 import org.projectnessie.cel.common.types.ref.TypeAdapterSupport;
@@ -42,11 +42,11 @@ public final class JacksonRegistry implements TypeRegistry {
   final ObjectMapper objectMapper;
   private final SerializerProvider serializationProvider;
   private final TypeFactory typeFactory;
-  private final Map<Class<?>, JacksonTypeDescription> knownTypes = new HashMap<>();
-  private final Map<String, JacksonTypeDescription> knownTypesByName = new HashMap<>();
+  private final Map<Class<?>, JacksonTypeDescription> knownTypes = new ConcurrentHashMap<>();
+  private final Map<String, JacksonTypeDescription> knownTypesByName = new ConcurrentHashMap<>();
 
-  private final Map<Class<?>, JacksonEnumDescription> enumMap = new HashMap<>();
-  private final Map<String, JacksonEnumValue> enumValues = new HashMap<>();
+  private final Map<Class<?>, JacksonEnumDescription> enumMap = new ConcurrentHashMap<>();
+  private final Map<String, JacksonEnumValue> enumValues = new ConcurrentHashMap<>();
 
   private JacksonRegistry() {
     this.objectMapper = new ObjectMapper();
@@ -149,7 +149,7 @@ public final class JacksonRegistry implements TypeRegistry {
     }
   }
 
-  JacksonEnumDescription enumDescription(Class<?> clazz) {
+  synchronized JacksonEnumDescription enumDescription(Class<?> clazz) {
     if (!Enum.class.isAssignableFrom(clazz)) {
       throw new IllegalArgumentException("only enum allowed here");
     }
@@ -174,7 +174,7 @@ public final class JacksonRegistry implements TypeRegistry {
     return enumDesc;
   }
 
-  JacksonTypeDescription typeDescription(Class<?> clazz) {
+  synchronized JacksonTypeDescription typeDescription(Class<?> clazz) {
     if (Enum.class.isAssignableFrom(clazz)) {
       throw new IllegalArgumentException("enum not allowed here");
     }

--- a/jackson/src/test/java/org/projectnessie/cel/types/jackson/Jackson2RegistryTest.java
+++ b/jackson/src/test/java/org/projectnessie/cel/types/jackson/Jackson2RegistryTest.java
@@ -27,8 +27,15 @@ import static org.projectnessie.cel.common.types.TimestampT.timestampOf;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.projectnessie.cel.common.types.Err;
 import org.projectnessie.cel.common.types.IntT;
@@ -196,5 +203,68 @@ class Jackson2RegistryTest {
     TypeRegistry reg = JacksonRegistry.newRegistry();
     assertThatThrownBy(() -> reg.registerType(IntT.IntType))
         .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void concurrentFirstTypeDiscovery() throws Exception {
+    JacksonRegistry reg = (JacksonRegistry) JacksonRegistry.newRegistry();
+    RefVariantB refVariantB = RefVariantB.of("main", "cafebabe123412341234123412341234");
+    ExecutorService executor = Executors.newFixedThreadPool(16);
+    try {
+      CountDownLatch ready = new CountDownLatch(16);
+      CountDownLatch start = new CountDownLatch(1);
+      List<Future<Val>> futures = new ArrayList<>();
+      for (int i = 0; i < 16; i++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  ready.countDown();
+                  assertThat(start.await(10, TimeUnit.SECONDS)).isTrue();
+                  return reg.nativeToValue(refVariantB);
+                }));
+      }
+
+      assertThat(ready.await(10, TimeUnit.SECONDS)).isTrue();
+      start.countDown();
+
+      for (Future<Val> future : futures) {
+        assertThat(future.get(10, TimeUnit.SECONDS)).isInstanceOf(ObjectT.class);
+      }
+      assertThat(reg.findType(refVariantB.getClass().getName())).isNotNull();
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  void concurrentFirstEnumDiscovery() throws Exception {
+    JacksonRegistry reg = (JacksonRegistry) JacksonRegistry.newRegistry();
+    ExecutorService executor = Executors.newFixedThreadPool(16);
+    try {
+      CountDownLatch ready = new CountDownLatch(16);
+      CountDownLatch start = new CountDownLatch(1);
+      List<Future<JacksonEnumDescription>> futures = new ArrayList<>();
+      for (int i = 0; i < 16; i++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  ready.countDown();
+                  assertThat(start.await(10, TimeUnit.SECONDS)).isTrue();
+                  return reg.enumDescription(AnEnum.class);
+                }));
+      }
+
+      assertThat(ready.await(10, TimeUnit.SECONDS)).isTrue();
+      start.countDown();
+
+      JacksonEnumDescription first = futures.get(0).get(10, TimeUnit.SECONDS);
+      for (Future<JacksonEnumDescription> future : futures) {
+        assertThat(future.get(10, TimeUnit.SECONDS)).isSameAs(first);
+      }
+      assertThat(reg.findIdent(AnEnum.class.getName() + "." + AnEnum.ENUM_VALUE_2.name()))
+          .isNotNull();
+    } finally {
+      executor.shutdownNow();
+    }
   }
 }

--- a/jackson3/src/main/java/org/projectnessie/cel/types/jackson3/Jackson3Registry.java
+++ b/jackson3/src/main/java/org/projectnessie/cel/types/jackson3/Jackson3Registry.java
@@ -17,8 +17,8 @@ package org.projectnessie.cel.types.jackson3;
 
 import static org.projectnessie.cel.common.types.Err.newErr;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.projectnessie.cel.common.types.ref.FieldType;
 import org.projectnessie.cel.common.types.ref.Type;
 import org.projectnessie.cel.common.types.ref.TypeAdapterSupport;
@@ -44,11 +44,11 @@ public final class Jackson3Registry implements TypeRegistry {
   final ObjectMapper objectMapper;
   private final SerializationContextExt serializationContextExt;
   private final TypeFactory typeFactory;
-  private final Map<Class<?>, JacksonTypeDescription> knownTypes = new HashMap<>();
-  private final Map<String, JacksonTypeDescription> knownTypesByName = new HashMap<>();
+  private final Map<Class<?>, JacksonTypeDescription> knownTypes = new ConcurrentHashMap<>();
+  private final Map<String, JacksonTypeDescription> knownTypesByName = new ConcurrentHashMap<>();
 
-  private final Map<Class<?>, JacksonEnumDescription> enumMap = new HashMap<>();
-  private final Map<String, JacksonEnumValue> enumValues = new HashMap<>();
+  private final Map<Class<?>, JacksonEnumDescription> enumMap = new ConcurrentHashMap<>();
+  private final Map<String, JacksonEnumValue> enumValues = new ConcurrentHashMap<>();
 
   private Jackson3Registry() {
     JsonMapper.Builder b = JsonMapper.builder();
@@ -160,7 +160,7 @@ public final class Jackson3Registry implements TypeRegistry {
     }
   }
 
-  JacksonEnumDescription enumDescription(Class<?> clazz) {
+  synchronized JacksonEnumDescription enumDescription(Class<?> clazz) {
     if (!Enum.class.isAssignableFrom(clazz)) {
       throw new IllegalArgumentException("only enum allowed here");
     }
@@ -185,7 +185,7 @@ public final class Jackson3Registry implements TypeRegistry {
     return enumDesc;
   }
 
-  JacksonTypeDescription typeDescription(Class<?> clazz) {
+  synchronized JacksonTypeDescription typeDescription(Class<?> clazz) {
     if (Enum.class.isAssignableFrom(clazz)) {
       throw new IllegalArgumentException("enum not allowed here");
     }

--- a/jackson3/src/main/java/org/projectnessie/cel/types/jackson3/Jackson3Registry.java
+++ b/jackson3/src/main/java/org/projectnessie/cel/types/jackson3/Jackson3Registry.java
@@ -169,20 +169,11 @@ public final class Jackson3Registry implements TypeRegistry {
     if (ed != null) {
       return ed;
     }
-    ed = computeEnumDescription(clazz);
+    JavaType javaType = typeFactory.constructType(clazz);
+    ed = new JacksonEnumDescription(javaType);
+    ed.buildValues().forEach(v -> enumValues.put(v.fullyQualifiedName(), v));
     enumMap.put(clazz, ed);
     return ed;
-  }
-
-  private JacksonEnumDescription computeEnumDescription(Class<?> clazz) {
-    JavaType javaType = typeFactory.constructType(clazz);
-
-    JacksonEnumDescription enumDesc = new JacksonEnumDescription(javaType);
-    enumMap.put(clazz, enumDesc);
-
-    enumDesc.buildValues().forEach(v -> enumValues.put(v.fullyQualifiedName(), v));
-
-    return enumDesc;
   }
 
   synchronized JacksonTypeDescription typeDescription(Class<?> clazz) {

--- a/jackson3/src/test/java/org/projectnessie/cel/types/jackson3/Jackson3RegistryTest.java
+++ b/jackson3/src/test/java/org/projectnessie/cel/types/jackson3/Jackson3RegistryTest.java
@@ -27,8 +27,15 @@ import static org.projectnessie.cel.common.types.TimestampT.timestampOf;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.projectnessie.cel.common.types.Err;
 import org.projectnessie.cel.common.types.IntT;
@@ -196,5 +203,68 @@ class Jackson3RegistryTest {
     TypeRegistry reg = Jackson3Registry.newRegistry();
     assertThatThrownBy(() -> reg.registerType(IntT.IntType))
         .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void concurrentFirstTypeDiscovery() throws Exception {
+    Jackson3Registry reg = (Jackson3Registry) Jackson3Registry.newRegistry();
+    RefVariantB refVariantB = RefVariantB.of("main", "cafebabe123412341234123412341234");
+    ExecutorService executor = Executors.newFixedThreadPool(16);
+    try {
+      CountDownLatch ready = new CountDownLatch(16);
+      CountDownLatch start = new CountDownLatch(1);
+      List<Future<Val>> futures = new ArrayList<>();
+      for (int i = 0; i < 16; i++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  ready.countDown();
+                  assertThat(start.await(10, TimeUnit.SECONDS)).isTrue();
+                  return reg.nativeToValue(refVariantB);
+                }));
+      }
+
+      assertThat(ready.await(10, TimeUnit.SECONDS)).isTrue();
+      start.countDown();
+
+      for (Future<Val> future : futures) {
+        assertThat(future.get(10, TimeUnit.SECONDS)).isInstanceOf(ObjectT.class);
+      }
+      assertThat(reg.findType(refVariantB.getClass().getName())).isNotNull();
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  void concurrentFirstEnumDiscovery() throws Exception {
+    Jackson3Registry reg = (Jackson3Registry) Jackson3Registry.newRegistry();
+    ExecutorService executor = Executors.newFixedThreadPool(16);
+    try {
+      CountDownLatch ready = new CountDownLatch(16);
+      CountDownLatch start = new CountDownLatch(1);
+      List<Future<JacksonEnumDescription>> futures = new ArrayList<>();
+      for (int i = 0; i < 16; i++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  ready.countDown();
+                  assertThat(start.await(10, TimeUnit.SECONDS)).isTrue();
+                  return reg.enumDescription(AnEnum.class);
+                }));
+      }
+
+      assertThat(ready.await(10, TimeUnit.SECONDS)).isTrue();
+      start.countDown();
+
+      JacksonEnumDescription first = futures.get(0).get(10, TimeUnit.SECONDS);
+      for (Future<JacksonEnumDescription> future : futures) {
+        assertThat(future.get(10, TimeUnit.SECONDS)).isSameAs(first);
+      }
+      assertThat(reg.findIdent(AnEnum.class.getName() + "." + AnEnum.ENUM_VALUE_2.name()))
+          .isNotNull();
+    } finally {
+      executor.shutdownNow();
+    }
   }
 }


### PR DESCRIPTION
Protect first-use Jackson type and enum discovery when registries are shared across evaluations. Use concurrent maps plus synchronized discovery to avoid unsafe cache mutation without relying on recursive computeIfAbsent.