### PR TITLE
Index protobuf map lookups lazily

### DIFF
--- a/core/src/main/java/org/projectnessie/cel/common/types/pb/FieldDescription.java
+++ b/core/src/main/java/org/projectnessie/cel/common/types/pb/FieldDescription.java
@@ -567,6 +567,8 @@ public final class FieldDescription extends Description {
     private final List<?> entries;
     private final FieldDescriptor keyDesc;
     private final FieldDescriptor valueDesc;
+    private volatile Map<Val, Val> indexedEntries;
+    private volatile boolean scanned;
 
     private ProtoMapT(TypeAdapter adapter, FieldDescriptor field, List<?> entries) {
       this.adapter = adapter;
@@ -624,6 +626,18 @@ public final class FieldDescription extends Description {
 
     @Override
     public Val find(Val key) {
+      Map<Val, Val> index = indexedEntries;
+      if (index != null) {
+        return index.get(key);
+      }
+      if (!scanned || entries.size() <= 1) {
+        scanned = true;
+        return scan(key);
+      }
+      return indexedEntries().get(key);
+    }
+
+    private Val scan(Val key) {
       for (Object entry : entries) {
         Val candidate = adapter.nativeToValue(mapEntryKey(entry));
         if (candidate.equal(key) == True) {
@@ -631,6 +645,26 @@ public final class FieldDescription extends Description {
         }
       }
       return null;
+    }
+
+    private Map<Val, Val> indexedEntries() {
+      Map<Val, Val> index = indexedEntries;
+      if (index != null) {
+        return index;
+      }
+      synchronized (this) {
+        index = indexedEntries;
+        if (index == null) {
+          index = new HashMap<>(entries.size() * 4 / 3 + 1);
+          for (Object entry : entries) {
+            Val key = adapter.nativeToValue(mapEntryKey(entry));
+            Val value = adapter.nativeToValue(mapEntryValue(entry));
+            index.putIfAbsent(key, value);
+          }
+          indexedEntries = index;
+        }
+        return index;
+      }
     }
 
     private Map<Object, Object> toJavaMap() {

--- a/core/src/test/java/org/projectnessie/cel/common/types/pb/FieldDescriptionTest.java
+++ b/core/src/test/java/org/projectnessie/cel/common/types/pb/FieldDescriptionTest.java
@@ -16,6 +16,10 @@
 package org.projectnessie.cel.common.types.pb;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.projectnessie.cel.common.types.BoolT.False;
+import static org.projectnessie.cel.common.types.BoolT.True;
+import static org.projectnessie.cel.common.types.StringT.stringOf;
+import static org.projectnessie.cel.common.types.UintT.uintOf;
 import static org.projectnessie.cel.common.types.pb.Db.newDb;
 
 import com.google.api.expr.test.v1.proto3.TestAllTypesProto.NestedTestAllTypes;
@@ -40,6 +44,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.projectnessie.cel.common.ULong;
 import org.projectnessie.cel.common.types.TimestampT;
+import org.projectnessie.cel.common.types.traits.Mapper;
 
 public class FieldDescriptionTest {
 
@@ -176,6 +181,32 @@ public class FieldDescriptionTest {
         .isEqualTo(Collections.singletonMap(ULong.valueOf(-1L), "large"));
     assertThat(td.fieldByName("map_uint64_uint64").getFrom(pbdb, dynMsg))
         .isEqualTo(Collections.singletonMap(ULong.valueOf(-1L), ULong.valueOf(Long.MIN_VALUE)));
+  }
+
+  @Test
+  void getFieldProtoMapSupportsRepeatedLookup() {
+    Db pbdb = newDb();
+    ProtoTypeRegistry registry = ProtoTypeRegistry.newRegistry(TestAllTypes.getDefaultInstance());
+    TestAllTypes msg =
+        TestAllTypes.newBuilder()
+            .putMapUint64String(1L, "one")
+            .putMapUint64String(2L, "two")
+            .putMapUint64String(-1L, "large")
+            .build();
+    pbdb.registerMessage(msg);
+    PbTypeDescription td = pbdb.describeType(msg.getDescriptorForType().getFullName());
+    assertThat(td).isNotNull();
+
+    FieldDescription field = td.fieldByName("map_uint64_string");
+    assertThat(field).isNotNull();
+
+    Mapper map = (Mapper) field.getField(msg, registry);
+    assertThat(map.find(uintOf(2)).equal(stringOf("two"))).isSameAs(True);
+    assertThat(map.find(uintOf(-1L)).equal(stringOf("large"))).isSameAs(True);
+    assertThat(map.find(uintOf(1)).equal(stringOf("one"))).isSameAs(True);
+    assertThat(map.find(uintOf(42))).isNull();
+    assertThat(map.contains(uintOf(2))).isSameAs(True);
+    assertThat(map.contains(uintOf(42))).isSameAs(False);
   }
 
   static class TestCase {


### PR DESCRIPTION
Keep protobuf map fields scan-based for the first lookup, then build a CEL-value index for repeated lookups.

This avoids repeated O(n) scans for repeated map access while preserving missing-key and unsigned-key behavior.