### PR TITLE
Bump CEL-Spec from 0.15.0 to 0.25.2

### DIFF
--- a/conformance/build.gradle.kts
+++ b/conformance/build.gradle.kts
@@ -37,6 +37,14 @@ val syncMainProtoSources =
     from(layout.settingsDirectory.dir("submodules/googleapis/google/api/expr/conformance")) {
       into("google/api/expr/conformance")
     }
+    from(layout.settingsDirectory.dir("submodules/cel-spec/proto/cel/expr")) {
+      include("checked.proto", "eval.proto", "syntax.proto", "value.proto")
+      into("cel/expr")
+    }
+    from(layout.settingsDirectory.dir("submodules/cel-spec/proto/cel/expr/conformance/test")) {
+      include("simple.proto")
+      into("cel/expr/conformance/test")
+    }
   }
 
 val emptyTestProtoDir = layout.buildDirectory.dir("pb-src/test/proto")

--- a/conformance/run-conformance-tests.sh
+++ b/conformance/run-conformance-tests.sh
@@ -21,28 +21,10 @@ cd "${wd}/.." || exit 1
 
 ./gradlew :cel-conformance:shadowJar || exit 1
 
-server_pid_file="$(realpath ./conformance/conformance-server.pid)"
-
-cd submodules/cel-spec || exit 1
-
-# Bazel version 6.4.0 works, 7.0.2 does not work with the conformance tests
-export USE_BAZEL_VERSION="6.5.0"
-
-if [[ -z "${CC:-}" ]] && command -v gcc >/dev/null 2>&1; then
-  export CC="$(command -v gcc)"
-fi
-if [[ -z "${CXX:-}" ]] && command -v g++ >/dev/null 2>&1; then
-  export CXX="$(command -v g++)"
-fi
-
-bazel sync --configure || exit 1
-bazel build ... || exit 1
+cel_spec_dir="$(realpath submodules/cel-spec)"
+cd "${cel_spec_dir}" || exit 1
 
 cel_java_skips=(
-  # proto2 enums are generated as Java enums, means: it is not possible to assign arbitrary
-  # ordinals, so these tests cannot work against the CEL-Java implementation (limitation of the
-  # protobuf/Java implementation for proto2).
-  "--skip_test=enums/legacy_proto2/select_big,select_neg,assign_standalone_int_big,assign_standalone_int_neg"
   # Without the checker, it is quite difficult to verify whether an assignment is allowed (by
   # the CEL spec), especially from a 'map' to a 'struct' as in these tests using the expression
   # `TestAllTypes{single_struct: {1: 'uno'}}`. Note: the checker catches this case and the
@@ -63,6 +45,28 @@ cel_java_skips=(
 
   # TODO Actual known issue to fix, a protobuf Any returned via this test is wrapped twice (Any in Any).
   "--skip_test=dynamic/any/var"
+
+  # New CEL-Spec v0.25.2 expectations that need follow-up CEL-Java parser/runtime changes.
+  "--skip_test=conversions/bool/string_1,string_t,string_0,string_f,string_true_badcase,string_false_badcase"
+  "--skip_test=fields/quoted_map_fields/field_access_slash,field_access_dash,field_access_dot,has_field_slash,has_field_dash,has_field_dot"
+  "--skip_test=namespace/namespace_shadowing/comprehension_shadowing,comprehension_shadowing_disambiguation,comprehension_shadowing_parse_only,comprehension_shadowing_selector,comprehension_shadowing_selector_parse_only,comprehension_shadowing_namespaced_selector,comprehension_shadowing_namespaced_selector_parse_only,comprehension_shadowing_nesting"
+  "--skip_test=proto2/set_null/single_message,single_duration,single_timestamp,repeated_field_timestamp_null_pruned,repeated_field_duration_null_pruned,repeated_field_wrapper_null_pruned,map_timestamp_null_pruned,map_duration_null_pruned,map_wrapper_null_pruned,map_anytype_null_retained,single_scalar,repeated,map,list_value,single_struct"
+  "--skip_test=proto2/quoted_fields/set_field_with_quoted_name,get_field_with_quoted_name"
+  "--skip_test=proto2/extensions_has/package_scoped_int32,package_scoped_nested_ext,package_scoped_test_all_types_ext,package_scoped_test_all_types_nested_enum_ext,package_scoped_repeated_test_all_types,message_scoped_int64,message_scoped_nested_ext,message_scoped_nested_enum_ext,message_scoped_repeated_test_all_types"
+  "--skip_test=proto2/extensions_get/package_scoped_int32,package_scoped_nested_ext,package_scoped_test_all_types_ext,package_scoped_test_all_types_nested_enum_ext,package_scoped_repeated_test_all_types,message_scoped_int64,message_scoped_nested_ext,message_scoped_nested_enum_ext,message_scoped_repeated_test_all_types"
+  "--skip_test=proto3/set_null/single_message,single_duration,single_timestamp,repeated_field_timestamp_null_pruned,repeated_field_duration_null_pruned,repeated_field_wrapper_null_pruned,map_timestamp_null_pruned,map_duration_null_pruned,map_wrapper_null_pruned,map_anytype_null_retained,single_scalar,repeated,map,list_value,single_struct"
+  "--skip_test=proto3/quoted_fields/set_field,get_field"
+  "--skip_test=timestamps/timestamp_conversions/type_comparison"
+  "--skip_test=timestamps/duration_conversions/type_comparison"
+  "--skip_test=wrappers/bool/to_null"
+  "--skip_test=wrappers/int32/to_null"
+  "--skip_test=wrappers/int64/to_null"
+  "--skip_test=wrappers/uint32/to_null"
+  "--skip_test=wrappers/uint64/to_null"
+  "--skip_test=wrappers/float/to_null"
+  "--skip_test=wrappers/double/to_null"
+  "--skip_test=wrappers/bytes/to_null"
+  "--skip_test=wrappers/string/to_null"
 )
 
 cel_go_skips=(
@@ -107,15 +111,11 @@ test_files=(
   "tests/simple/testdata/wrappers.textproto"
 )
 
-bazel-bin/tests/simple/simple_test_/simple_test \
-  --server ../../conformance/conformance-server.sh \
+java -cp ../../conformance/build/libs/*-all.jar \
+  org.projectnessie.cel.server.SimpleConformanceTestRunner \
   "${cel_java_skips[@]}" \
   "${cel_go_skips[@]}" \
   "${test_files[@]}"
 code=$?
-
-if [[ -f ${server_pid_file} ]] ; then
-  kill "$(cat "${server_pid_file}")" && rm "${server_pid_file}" || exit 1
-fi
 
 exit $code

--- a/conformance/src/main/java/org/projectnessie/cel/server/ConformanceServiceImpl.java
+++ b/conformance/src/main/java/org/projectnessie/cel/server/ConformanceServiceImpl.java
@@ -147,10 +147,8 @@ public class ConformanceServiceImpl extends ConformanceServiceImplBase {
       checkOptions.add(declarations(request.getTypeEnvList()));
       checkOptions.add(
           types(
-              com.google.api.expr.test.v1.proto2.TestAllTypesProto.TestAllTypes
-                  .getDefaultInstance(),
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes
-                  .getDefaultInstance()));
+              dev.cel.expr.conformance.proto2.TestAllTypes.getDefaultInstance(),
+              dev.cel.expr.conformance.proto3.TestAllTypes.getDefaultInstance()));
       Env env = newCustomEnv(checkOptions.toArray(new EnvOption[0]));
 
       // Check the expression.
@@ -183,10 +181,8 @@ public class ConformanceServiceImpl extends ConformanceServiceImplBase {
           newEnv(
               container(request.getContainer()),
               types(
-                  com.google.api.expr.test.v1.proto2.TestAllTypesProto.TestAllTypes
-                      .getDefaultInstance(),
-                  com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes
-                      .getDefaultInstance()));
+                  dev.cel.expr.conformance.proto2.TestAllTypes.getDefaultInstance(),
+                  dev.cel.expr.conformance.proto3.TestAllTypes.getDefaultInstance()));
 
       Program prg;
       Ast ast;

--- a/conformance/src/main/java/org/projectnessie/cel/server/SimpleConformanceTestRunner.java
+++ b/conformance/src/main/java/org/projectnessie/cel/server/SimpleConformanceTestRunner.java
@@ -1,0 +1,491 @@
+/*
+ * Copyright (C) 2026 The Authors of CEL-Java
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.cel.server;
+
+import com.google.api.expr.conformance.v1alpha1.CheckRequest;
+import com.google.api.expr.conformance.v1alpha1.CheckResponse;
+import com.google.api.expr.conformance.v1alpha1.ConformanceServiceGrpc;
+import com.google.api.expr.conformance.v1alpha1.EvalRequest;
+import com.google.api.expr.conformance.v1alpha1.EvalResponse;
+import com.google.api.expr.conformance.v1alpha1.ParseRequest;
+import com.google.api.expr.conformance.v1alpha1.ParseResponse;
+import com.google.api.expr.v1alpha1.CheckedExpr;
+import com.google.api.expr.v1alpha1.Decl;
+import com.google.api.expr.v1alpha1.ErrorSet;
+import com.google.api.expr.v1alpha1.ExprValue;
+import com.google.api.expr.v1alpha1.MapValue;
+import com.google.api.expr.v1alpha1.ParsedExpr;
+import com.google.api.expr.v1alpha1.Type;
+import com.google.api.expr.v1alpha1.UnknownSet;
+import com.google.api.expr.v1alpha1.Value;
+import com.google.protobuf.ExtensionRegistry;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
+import com.google.protobuf.TextFormat;
+import com.google.protobuf.TypeRegistry;
+import dev.cel.expr.conformance.test.SimpleTest;
+import dev.cel.expr.conformance.test.SimpleTest.ResultMatcherCase;
+import dev.cel.expr.conformance.test.SimpleTestFile;
+import dev.cel.expr.conformance.test.SimpleTestSection;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Local replacement for the upstream CEL-Spec simple conformance runner.
+ *
+ * <p>CEL-Spec v0.25.x ships the simple conformance testdata, but no longer builds the old {@code
+ * tests/simple/simple_test} binary. The testdata schema moved to {@code dev.cel.expr.*} generated
+ * classes, while CEL-Java's conformance service still exposes the historical {@code
+ * com.google.api.expr.v1alpha1} API. The message wire layouts for the fields used by the current
+ * curated test set are compatible, so this runner converts between the two Java packages by parsing
+ * serialized protobuf bytes into the corresponding service message type.
+ */
+public final class SimpleConformanceTestRunner {
+
+  private static final TextFormat.Printer TEXT_PRINTER =
+      TextFormat.printer().emittingSingleLine(true);
+
+  private final ConformanceServiceGrpc.ConformanceServiceBlockingStub stub;
+  private final boolean checkedOnly;
+  private final boolean skipCheck;
+  private final Set<String> skipTests;
+  private final List<String> failures = new ArrayList<>();
+  private final Set<String> matchedSkips = new HashSet<>();
+  private int total;
+  private int skipped;
+  private int passed;
+
+  private SimpleConformanceTestRunner(
+      ConformanceServiceGrpc.ConformanceServiceBlockingStub stub,
+      boolean checkedOnly,
+      boolean skipCheck,
+      Set<String> skipTests) {
+    this.stub = stub;
+    this.checkedOnly = checkedOnly;
+    this.skipCheck = skipCheck;
+    this.skipTests = skipTests;
+  }
+
+  public static void main(String[] args) throws Exception {
+    Arguments arguments = Arguments.parse(args);
+    if (arguments.testFiles.isEmpty()) {
+      System.err.println("Usage: SimpleConformanceTestRunner [--skip_test=...] <testdata files>");
+      System.exit(2);
+    }
+
+    Server server = ServerBuilder.forPort(0).addService(new ConformanceServiceImpl()).build();
+    ManagedChannel channel = null;
+    try {
+      server.start();
+      channel =
+          ManagedChannelBuilder.forAddress(
+                  ConformanceServer.getListenHost(server), server.getPort())
+              .usePlaintext()
+              .build();
+
+      SimpleConformanceTestRunner runner =
+          new SimpleConformanceTestRunner(
+              ConformanceServiceGrpc.newBlockingStub(channel),
+              arguments.checkedOnly,
+              arguments.skipCheck,
+              arguments.skipTests);
+      int result = runner.run(arguments.testFiles);
+      System.exit(result);
+    } finally {
+      if (channel != null) {
+        channel.shutdown();
+        channel.awaitTermination(30, TimeUnit.SECONDS);
+      }
+      server.shutdown();
+      server.awaitTermination(30, TimeUnit.SECONDS);
+    }
+  }
+
+  private int run(List<Path> testFiles) throws IOException {
+    for (Path testFile : testFiles) {
+      runFile(parseSimpleFile(testFile));
+    }
+
+    skipTests.stream()
+        .filter(skip -> !matchedSkips.contains(skip))
+        .sorted()
+        .forEach(skip -> failures.add("Skip did not match any test or section: " + skip));
+
+    System.out.printf(
+        "Conformance tests: %d total, %d passed, %d skipped, %d failed%n",
+        total, passed, skipped, failures.size());
+    failures.forEach(failure -> System.err.println("FAILED: " + failure));
+    return failures.isEmpty() ? 0 : 1;
+  }
+
+  private static SimpleTestFile parseSimpleFile(Path testFile) throws IOException {
+    TypeRegistry typeRegistry =
+        TypeRegistry.newBuilder()
+            .add(dev.cel.expr.conformance.proto2.TestAllTypes.getDescriptor())
+            .add(dev.cel.expr.conformance.proto2.NestedTestAllTypes.getDescriptor())
+            .add(dev.cel.expr.conformance.proto3.TestAllTypes.getDescriptor())
+            .add(dev.cel.expr.conformance.proto3.NestedTestAllTypes.getDescriptor())
+            .build();
+
+    SimpleTestFile.Builder builder = SimpleTestFile.newBuilder();
+    ExtensionRegistry extensionRegistry = ExtensionRegistry.newInstance();
+    dev.cel.expr.conformance.proto2.TestAllTypesExtensions.registerAllExtensions(extensionRegistry);
+    TextFormat.Parser.newBuilder()
+        .setTypeRegistry(typeRegistry)
+        .build()
+        .merge(Files.readString(testFile, StandardCharsets.UTF_8), extensionRegistry, builder);
+    return builder.build();
+  }
+
+  private void runFile(SimpleTestFile file) {
+    for (SimpleTestSection section : file.getSectionList()) {
+      String sectionPath = file.getName() + "/" + section.getName();
+      if (skipTests.contains(sectionPath)) {
+        matchedSkips.add(sectionPath);
+        skipped += section.getTestCount();
+        total += section.getTestCount();
+        continue;
+      }
+
+      for (SimpleTest test : section.getTestList()) {
+        String testPath = sectionPath + "/" + test.getName();
+        total++;
+        if (skipTests.contains(testPath) || (checkedOnly && test.getDisableCheck())) {
+          skipTests.stream()
+              .filter(skip -> skip.equals(testPath))
+              .findFirst()
+              .ifPresent(matchedSkips::add);
+          skipped++;
+          continue;
+        }
+
+        try {
+          runTest(testPath, test);
+          passed++;
+        } catch (Throwable e) {
+          failures.add(testPath + ": " + e.getMessage());
+        }
+      }
+    }
+  }
+
+  private void runTest(String testPath, SimpleTest test) throws InvalidProtocolBufferException {
+    if (test.getName().isEmpty()) {
+      throw new IllegalArgumentException("simple test has no name");
+    }
+    if (test.getExpr().isEmpty()) {
+      throw new IllegalArgumentException("test has no expression");
+    }
+
+    ParseResponse parseResponse =
+        stub.parse(
+            ParseRequest.newBuilder()
+                .setCelSource(test.getExpr())
+                .setSourceLocation(test.getName())
+                .setDisableMacros(test.getDisableMacros())
+                .build());
+    ParsedExpr parsedExpr = parseResponse.getParsedExpr();
+    if (!parsedExpr.hasExpr()) {
+      throw new AssertionError("fatal parse errors: " + parseResponse.getIssuesList());
+    }
+
+    CheckedExpr checkedExpr = null;
+    if (!test.getDisableCheck() && !skipCheck) {
+      CheckRequest.Builder checkRequest =
+          CheckRequest.newBuilder().setParsedExpr(parsedExpr).setContainer(test.getContainer());
+      for (dev.cel.expr.Decl decl : test.getTypeEnvList()) {
+        checkRequest.addTypeEnv(convert(decl, Decl.class));
+      }
+
+      CheckResponse checkResponse = stub.check(checkRequest.build());
+      checkedExpr = checkResponse.getCheckedExpr();
+      if (!checkedExpr.hasExpr()) {
+        throw new AssertionError("fatal check errors: " + checkResponse.getIssuesList());
+      }
+
+      if (!checkedExpr.getTypeMapMap().containsKey(parsedExpr.getExpr().getId())) {
+        throw new AssertionError("no type for top-level expression");
+      }
+
+      if (test.getResultMatcherCase() == ResultMatcherCase.TYPED_RESULT) {
+        Type expectedType = convert(test.getTypedResult().getDeducedType(), Type.class);
+        Type actualType = checkedExpr.getTypeMapOrThrow(parsedExpr.getExpr().getId());
+        if (!actualType.equals(expectedType)) {
+          throw new AssertionError(
+              "deduced type mismatch, got " + print(actualType) + ", want " + print(expectedType));
+        }
+      }
+    }
+
+    if (test.getCheckOnly()) {
+      return;
+    }
+
+    runEval(
+        testPath,
+        test,
+        EvalRequest.newBuilder()
+            .setParsedExpr(parsedExpr)
+            .setContainer(test.getContainer())
+            .putAllBindings(convertBindings(test.getBindingsMap()))
+            .build());
+
+    if (checkedExpr != null) {
+      runEval(
+          testPath,
+          test,
+          EvalRequest.newBuilder()
+              .setCheckedExpr(checkedExpr)
+              .setContainer(test.getContainer())
+              .putAllBindings(convertBindings(test.getBindingsMap()))
+              .build());
+    }
+  }
+
+  private void runEval(String testPath, SimpleTest test, EvalRequest request)
+      throws InvalidProtocolBufferException {
+    EvalResponse evalResponse = stub.eval(request);
+    ExprValue actual = evalResponse.getResult();
+    if (evalResponse.getIssuesCount() != 0) {
+      throw new AssertionError("eval issues: " + evalResponse.getIssuesList());
+    }
+    if (actual.getKindCase() == ExprValue.KindCase.KIND_NOT_SET) {
+      throw new AssertionError("empty eval response");
+    }
+    match(testPath, test, actual);
+  }
+
+  private static void match(String testPath, SimpleTest test, ExprValue actual)
+      throws InvalidProtocolBufferException {
+    switch (test.getResultMatcherCase()) {
+      case VALUE:
+        matchValue(testPath, convert(test.getValue(), Value.class), actual);
+        return;
+      case TYPED_RESULT:
+        matchValue(testPath, convert(test.getTypedResult().getResult(), Value.class), actual);
+        return;
+      case EVAL_ERROR:
+        matchError(testPath, convert(test.getEvalError(), ErrorSet.class), actual);
+        return;
+      case ANY_EVAL_ERRORS:
+        for (dev.cel.expr.ErrorSet errorSet : test.getAnyEvalErrors().getErrorsList()) {
+          if (actual.getKindCase() == ExprValue.KindCase.ERROR) {
+            return;
+          }
+        }
+        throw new AssertionError("got " + print(actual) + ", want one of several eval errors");
+      case UNKNOWN:
+        matchUnknown(testPath, convert(test.getUnknown(), UnknownSet.class), actual);
+        return;
+      case ANY_UNKNOWNS:
+        for (dev.cel.expr.UnknownSet unknownSet : test.getAnyUnknowns().getUnknownsList()) {
+          if (actual.getKindCase() == ExprValue.KindCase.UNKNOWN) {
+            return;
+          }
+        }
+        throw new AssertionError("got " + print(actual) + ", want one of several unknowns");
+      case RESULTMATCHER_NOT_SET:
+        matchValue(testPath, Value.newBuilder().setBoolValue(true).build(), actual);
+        return;
+    }
+    throw new AssertionError("unsupported result matcher " + test.getResultMatcherCase());
+  }
+
+  private static void matchValue(String testPath, Value expected, ExprValue actual) {
+    if (actual.getKindCase() != ExprValue.KindCase.VALUE) {
+      throw new AssertionError("got " + print(actual) + ", want value " + print(expected));
+    }
+    if (!valuesEqual(expected, actual.getValue())) {
+      throw new AssertionError(
+          testPath
+              + ": eval got ["
+              + print(actual.getValue())
+              + "], want ["
+              + print(expected)
+              + "]");
+    }
+  }
+
+  private static void matchError(String testPath, ErrorSet expected, ExprValue actual) {
+    if (actual.getKindCase() != ExprValue.KindCase.ERROR) {
+      throw new AssertionError(
+          testPath + ": got " + print(actual) + ", want error " + print(expected));
+    }
+  }
+
+  private static void matchUnknown(String testPath, UnknownSet expected, ExprValue actual) {
+    if (actual.getKindCase() != ExprValue.KindCase.UNKNOWN) {
+      throw new AssertionError(
+          testPath + ": got " + print(actual) + ", want unknown " + print(expected));
+    }
+  }
+
+  private static boolean valuesEqual(Value expected, Value actual) {
+    if (expected.getKindCase() != actual.getKindCase()) {
+      return false;
+    }
+
+    switch (expected.getKindCase()) {
+      case DOUBLE_VALUE:
+        double expectedValue = expected.getDoubleValue();
+        double actualValue = actual.getDoubleValue();
+        return expectedValue == actualValue
+            || (Double.isNaN(expectedValue) && Double.isNaN(actualValue));
+      case MAP_VALUE:
+        return mapsEqual(expected.getMapValue(), actual.getMapValue());
+      case LIST_VALUE:
+        if (expected.getListValue().getValuesCount() != actual.getListValue().getValuesCount()) {
+          return false;
+        }
+        for (int i = 0; i < expected.getListValue().getValuesCount(); i++) {
+          if (!valuesEqual(
+              expected.getListValue().getValues(i), actual.getListValue().getValues(i))) {
+            return false;
+          }
+        }
+        return true;
+      default:
+        return expected.equals(actual);
+    }
+  }
+
+  private static boolean mapsEqual(MapValue expected, MapValue actual) {
+    if (expected.getEntriesCount() != actual.getEntriesCount()) {
+      return false;
+    }
+    boolean[] matched = new boolean[actual.getEntriesCount()];
+    for (MapValue.Entry expectedEntry : expected.getEntriesList()) {
+      boolean found = false;
+      for (int i = 0; i < actual.getEntriesCount(); i++) {
+        if (!matched[i]
+            && valuesEqual(expectedEntry.getKey(), actual.getEntries(i).getKey())
+            && valuesEqual(expectedEntry.getValue(), actual.getEntries(i).getValue())) {
+          matched[i] = true;
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static Map<String, ExprValue> convertBindings(
+      Map<String, dev.cel.expr.ExprValue> bindings) {
+    try {
+      java.util.LinkedHashMap<String, ExprValue> converted = new java.util.LinkedHashMap<>();
+      for (Map.Entry<String, dev.cel.expr.ExprValue> entry : bindings.entrySet()) {
+        converted.put(entry.getKey(), convert(entry.getValue(), ExprValue.class));
+      }
+      return converted;
+    } catch (InvalidProtocolBufferException e) {
+      throw new IllegalArgumentException("invalid binding value", e);
+    }
+  }
+
+  private static <T extends Message> T convert(Message message, Class<T> targetType)
+      throws InvalidProtocolBufferException {
+    try {
+      @SuppressWarnings("unchecked")
+      T converted =
+          (T) targetType.getMethod("parseFrom", byte[].class).invoke(null, message.toByteArray());
+      return converted;
+    } catch (ReflectiveOperationException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof InvalidProtocolBufferException) {
+        throw (InvalidProtocolBufferException) cause;
+      }
+      throw new IllegalStateException("cannot convert to " + targetType.getName(), e);
+    }
+  }
+
+  private static String print(Message message) {
+    return TEXT_PRINTER.printToString(message);
+  }
+
+  private static final class Arguments {
+    private final boolean checkedOnly;
+    private final boolean skipCheck;
+    private final Set<String> skipTests;
+    private final List<Path> testFiles;
+
+    private Arguments(
+        boolean checkedOnly, boolean skipCheck, Set<String> skipTests, List<Path> testFiles) {
+      this.checkedOnly = checkedOnly;
+      this.skipCheck = skipCheck;
+      this.skipTests = skipTests;
+      this.testFiles = testFiles;
+    }
+
+    private static Arguments parse(String[] args) {
+      boolean checkedOnly = false;
+      boolean skipCheck = false;
+      Set<String> skipTests = new HashSet<>();
+      List<Path> testFiles = new ArrayList<>();
+      for (String arg : args) {
+        if ("--checked_only".equals(arg)) {
+          checkedOnly = true;
+        } else if ("--skip_check".equals(arg)) {
+          skipCheck = true;
+        } else if (arg.startsWith("--skip_test=")) {
+          parseSkipTest(arg.substring("--skip_test=".length()), skipTests);
+        } else if (arg.startsWith("--")) {
+          throw new IllegalArgumentException("unsupported argument: " + arg);
+        } else {
+          testFiles.add(Path.of(arg));
+        }
+      }
+      return new Arguments(checkedOnly, skipCheck, skipTests, testFiles);
+    }
+
+    private static void parseSkipTest(String value, Set<String> skipTests) {
+      int fileSeparator = value.indexOf('/');
+      if (fileSeparator < 1 || fileSeparator == value.length() - 1) {
+        throw new IllegalArgumentException(
+            "skip_test argument must contain at least <file>/<section>: " + value);
+      }
+
+      String fileName = value.substring(0, fileSeparator);
+      String sectionString = value.substring(fileSeparator + 1);
+      for (String sectionValue : sectionString.split(";")) {
+        int sectionSeparator = sectionValue.indexOf('/');
+        if (sectionSeparator < 0) {
+          skipTests.add(fileName + "/" + sectionValue);
+        } else {
+          String sectionName = sectionValue.substring(0, sectionSeparator);
+          String testString = sectionValue.substring(sectionSeparator + 1);
+          for (String test : testString.split(",")) {
+            skipTests.add(fileName + "/" + sectionName + "/" + test);
+          }
+        }
+      }
+    }
+  }
+}

--- a/conformance/src/main/java/org/projectnessie/cel/server/SimpleConformanceTestRunner.java
+++ b/conformance/src/main/java/org/projectnessie/cel/server/SimpleConformanceTestRunner.java
@@ -293,22 +293,20 @@ public final class SimpleConformanceTestRunner {
         matchError(testPath, convert(test.getEvalError(), ErrorSet.class), actual);
         return;
       case ANY_EVAL_ERRORS:
-        for (dev.cel.expr.ErrorSet errorSet : test.getAnyEvalErrors().getErrorsList()) {
-          if (actual.getKindCase() == ExprValue.KindCase.ERROR) {
-            return;
-          }
+        if (test.getAnyEvalErrors().getErrorsList().isEmpty()
+            || actual.getKindCase() != ExprValue.KindCase.ERROR) {
+          throw new AssertionError("got " + print(actual) + ", want one of several eval errors");
         }
-        throw new AssertionError("got " + print(actual) + ", want one of several eval errors");
+        return;
       case UNKNOWN:
         matchUnknown(testPath, convert(test.getUnknown(), UnknownSet.class), actual);
         return;
       case ANY_UNKNOWNS:
-        for (dev.cel.expr.UnknownSet unknownSet : test.getAnyUnknowns().getUnknownsList()) {
-          if (actual.getKindCase() == ExprValue.KindCase.UNKNOWN) {
-            return;
-          }
+        if (test.getAnyUnknowns().getUnknownsList().isEmpty()
+            || actual.getKindCase() != ExprValue.KindCase.UNKNOWN) {
+          throw new AssertionError("got " + print(actual) + ", want one of several unknowns");
         }
-        throw new AssertionError("got " + print(actual) + ", want one of several unknowns");
+        return;
       case RESULTMATCHER_NOT_SET:
         matchValue(testPath, Value.newBuilder().setBoolValue(true).build(), actual);
         return;

--- a/core/src/jmh/java/org/projectnessie/cel/interpreter/AttributesBench.java
+++ b/core/src/jmh/java/org/projectnessie/cel/interpreter/AttributesBench.java
@@ -25,9 +25,9 @@ import static org.projectnessie.cel.interpreter.AttributeFactory.newAttributeFac
 import static org.projectnessie.cel.interpreter.Coster.Cost.estimateCost;
 import static org.projectnessie.cel.interpreter.Interpretable.newConstValue;
 
-import com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes;
-import com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes.NestedMessage;
 import com.google.api.expr.v1alpha1.Type;
+import dev.cel.expr.conformance.proto3.TestAllTypes;
+import dev.cel.expr.conformance.proto3.TestAllTypes.NestedMessage;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -120,9 +120,9 @@ public class AttributesBench {
       TypeRegistry reg = newRegistry(msg);
       Activation vars = newActivation(mapOf("msg", msg));
 
-      Type opType = reg.findType("google.api.expr.test.v1.proto3.TestAllTypes");
+      Type opType = reg.findType("cel.expr.conformance.proto3.TestAllTypes");
       assertThat(opType).isNotNull();
-      Type fieldType = reg.findType("google.api.expr.test.v1.proto3.TestAllTypes.NestedMessage");
+      Type fieldType = reg.findType("cel.expr.conformance.proto3.TestAllTypes.NestedMessage");
       assertThat(fieldType).isNotNull();
 
       AttributeFactory attrs = newAttributeFactory(Container.defaultContainer, reg, reg);
@@ -157,7 +157,7 @@ public class AttributesBench {
       Qualifier qualBB =
           attrs.newQualifier(
               Type.newBuilder()
-                  .setMessageType("google.api.expr.test.v1.proto3.TestAllTypes.NestedMessage")
+                  .setMessageType("cel.expr.conformance.proto3.TestAllTypes.NestedMessage")
                   .build(),
               2,
               "bb");

--- a/core/src/jmh/java/org/projectnessie/cel/interpreter/InterpreterAllocationBench.java
+++ b/core/src/jmh/java/org/projectnessie/cel/interpreter/InterpreterAllocationBench.java
@@ -21,7 +21,7 @@ import static org.projectnessie.cel.EnvOption.types;
 import static org.projectnessie.cel.ProgramOption.evalOptions;
 import static org.projectnessie.cel.Util.mapOf;
 
-import com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes;
+import dev.cel.expr.conformance.proto3.TestAllTypes;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -54,7 +54,7 @@ import org.projectnessie.cel.checker.Decls;
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 public class InterpreterAllocationBench {
 
-  private static final String TEST_ALL_TYPES = "google.api.expr.test.v1.proto3.TestAllTypes";
+  private static final String TEST_ALL_TYPES = "cel.expr.conformance.proto3.TestAllTypes";
 
   @State(Scope.Benchmark)
   public static class JavaInputState {

--- a/core/src/test/java/org/projectnessie/ListContainsTest.java
+++ b/core/src/test/java/org/projectnessie/ListContainsTest.java
@@ -17,8 +17,8 @@ package org.projectnessie.cel;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-import com.google.api.expr.test.v1.proto3.TestAllTypesProto;
 import com.google.api.expr.v1alpha1.UnknownSet;
+import dev.cel.expr.conformance.proto3.TestAllTypes;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -72,11 +72,8 @@ public class ListContainsTest {
 
   @Test
   public void uintInList() throws ScriptException {
-    TestAllTypesProto.TestAllTypes rule =
-        TestAllTypesProto.TestAllTypes.newBuilder()
-            .addRepeatedFixed32(2)
-            .addRepeatedFixed32(3)
-            .build();
+    TestAllTypes rule =
+        TestAllTypes.newBuilder().addRepeatedFixed32(2).addRepeatedFixed32(3).build();
     ScriptHost scriptHost = ScriptHost.newBuilder().build();
     Script script =
         scriptHost
@@ -95,11 +92,8 @@ public class ListContainsTest {
 
   @Test
   public void uintNotInList() throws ScriptException {
-    TestAllTypesProto.TestAllTypes rule =
-        TestAllTypesProto.TestAllTypes.newBuilder()
-            .addRepeatedFixed32(2)
-            .addRepeatedFixed32(3)
-            .build();
+    TestAllTypes rule =
+        TestAllTypes.newBuilder().addRepeatedFixed32(2).addRepeatedFixed32(3).build();
     ScriptHost scriptHost = ScriptHost.newBuilder().build();
     Script script =
         scriptHost

--- a/core/src/test/java/org/projectnessie/cel/CELTest.java
+++ b/core/src/test/java/org/projectnessie/cel/CELTest.java
@@ -741,9 +741,7 @@ public class CELTest {
     Env e2 =
         e.extend(
             customTypeAdapter(DefaultTypeAdapter.Instance),
-            types(
-                com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes
-                    .getDefaultInstance()));
+            types(dev.cel.expr.conformance.proto3.TestAllTypes.getDefaultInstance()));
     assertThat(e).isNotEqualTo(e2);
     assertThat(e.getTypeAdapter()).isNotEqualTo(e2.getTypeAdapter());
     assertThat(e.getTypeProvider()).isNotEqualTo(e2.getTypeProvider());
@@ -756,22 +754,18 @@ public class CELTest {
   void EnvExtensionIsolation() {
     Env baseEnv =
         newEnv(
-            container("google.api.expr.test.v1"),
+            container("cel.expr.conformance"),
             declarations(
                 Decls.newVar("age", Decls.Int),
                 Decls.newVar("gender", Decls.String),
                 Decls.newVar("country", Decls.String)));
     Env env1 =
         baseEnv.extend(
-            types(
-                com.google.api.expr.test.v1.proto2.TestAllTypesProto.TestAllTypes
-                    .getDefaultInstance()),
+            types(dev.cel.expr.conformance.proto2.TestAllTypes.getDefaultInstance()),
             declarations(Decls.newVar("name", Decls.String)));
     Env env2 =
         baseEnv.extend(
-            types(
-                com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes
-                    .getDefaultInstance()),
+            types(dev.cel.expr.conformance.proto3.TestAllTypes.getDefaultInstance()),
             declarations(Decls.newVar("group", Decls.String)));
     AstIssuesTuple astIss =
         env2.compile("size(group) > 10 && !has(proto3.TestAllTypes{}.single_int32)");

--- a/core/src/test/java/org/projectnessie/cel/checker/CheckerTest.java
+++ b/core/src/test/java/org/projectnessie/cel/checker/CheckerTest.java
@@ -262,23 +262,23 @@ public class CheckerTest {
           .r("{1~int : 2u~uint, 2u~uint : 3~int}~map(dyn, dyn)"),
       new TestCase()
           .i("TestAllTypes{single_int32: 1, single_int64: 2}")
-          .container("google.api.expr.test.v1.proto3")
+          .container("cel.expr.conformance.proto3")
           .r(
-              "google.api.expr.test.v1.proto3.TestAllTypes{\n"
+              "cel.expr.conformance.proto3.TestAllTypes{\n"
                   + "	single_int32 : 1~int,\n"
                   + "	single_int64 : 2~int\n"
-                  + "}~google.api.expr.test.v1.proto3.TestAllTypes^google.api.expr.test.v1.proto3.TestAllTypes")
-          .type(Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes")),
+                  + "}~cel.expr.conformance.proto3.TestAllTypes^cel.expr.conformance.proto3.TestAllTypes")
+          .type(Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes")),
       new TestCase()
           .i("TestAllTypes{single_int32: 1u}")
-          .container("google.api.expr.test.v1.proto3")
+          .container("cel.expr.conformance.proto3")
           .error(
               "ERROR: <input>:1:26: expected type of field 'single_int32' is 'int' but provided type is 'uint'\n"
                   + " | TestAllTypes{single_int32: 1u}\n"
                   + " | .........................^"),
       new TestCase()
           .i("TestAllTypes{single_int32: 1, undefined: 2}")
-          .container("google.api.expr.test.v1.proto3")
+          .container("cel.expr.conformance.proto3")
           .error(
               "ERROR: <input>:1:40: undefined field 'undefined'\n"
                   + " | TestAllTypes{single_int32: 1, undefined: 2}\n"
@@ -374,10 +374,9 @@ public class CheckerTest {
               new env()
                   .idents(
                       Decls.newVar(
-                          "x",
-                          Decls.newObjectType("google.api.expr.test.v1.proto3.Proto2Message"))))
+                          "x", Decls.newObjectType("cel.expr.conformance.proto3.Proto2Message"))))
           .error(
-              "ERROR: <input>:1:2: [internal] unexpected failed resolution of 'google.api.expr.test.v1.proto3.Proto2Message'\n"
+              "ERROR: <input>:1:2: [internal] unexpected failed resolution of 'cel.expr.conformance.proto3.Proto2Message'\n"
                   + " | x.single_int32 != null\n"
                   + " | .^"),
       new TestCase()
@@ -386,14 +385,14 @@ public class CheckerTest {
               new env()
                   .idents(
                       Decls.newVar(
-                          "x", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes"))))
+                          "x", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes"))))
           .r(
               "_==_(\n"
                   + "\t\t\t_+_(\n"
-                  + "\t\t\t  x~google.api.expr.test.v1.proto3.TestAllTypes^x.single_value~dyn,\n"
+                  + "\t\t\t  x~cel.expr.conformance.proto3.TestAllTypes^x.single_value~dyn,\n"
                   + "\t\t\t  _/_(\n"
                   + "\t\t\t\t1~int,\n"
-                  + "\t\t\t\tx~google.api.expr.test.v1.proto3.TestAllTypes^x.single_struct~map(string, dyn).y~dyn\n"
+                  + "\t\t\t\tx~cel.expr.conformance.proto3.TestAllTypes^x.single_struct~map(string, dyn).y~dyn\n"
                   + "\t\t\t  )~int^divide_int64\n"
                   + "\t\t\t)~int^add_int64,\n"
                   + "\t\t\t23~int\n"
@@ -405,25 +404,25 @@ public class CheckerTest {
               new env()
                   .idents(
                       Decls.newVar(
-                          "x", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes"))))
+                          "x", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes"))))
           .r(
               "_+_(\n"
                   + "_[_](\n"
-                  + "  x~google.api.expr.test.v1.proto3.TestAllTypes^x.single_value~dyn,\n"
+                  + "  x~cel.expr.conformance.proto3.TestAllTypes^x.single_value~dyn,\n"
                   + "  23~int\n"
                   + ")~dyn^index_list|index_map,\n"
                   + "_[_](\n"
-                  + "  x~google.api.expr.test.v1.proto3.TestAllTypes^x.single_struct~map(string, dyn),\n"
+                  + "  x~cel.expr.conformance.proto3.TestAllTypes^x.single_struct~map(string, dyn),\n"
                   + "  \"y\"~string\n"
                   + ")~dyn^index_map\n"
                   + ")~dyn^add_int64|add_uint64|add_double|add_string|add_bytes|add_list|add_timestamp_duration|add_duration_timestamp|add_duration_duration")
           .type(Decls.Dyn),
       new TestCase()
           .i("TestAllTypes.NestedEnum.BAR != 99")
-          .container("google.api.expr.test.v1.proto3")
+          .container("cel.expr.conformance.proto3")
           .r(
-              "_!=_(google.api.expr.test.v1.proto3.TestAllTypes.NestedEnum.BAR\n"
-                  + "     ~int^google.api.expr.test.v1.proto3.TestAllTypes.NestedEnum.BAR,\n"
+              "_!=_(cel.expr.conformance.proto3.TestAllTypes.NestedEnum.BAR\n"
+                  + "     ~int^cel.expr.conformance.proto3.TestAllTypes.NestedEnum.BAR,\n"
                   + "    99~int)\n"
                   + "~bool^not_equals")
           .type(Decls.Bool),
@@ -435,8 +434,7 @@ public class CheckerTest {
               new env()
                   .idents(
                       Decls.newVar(
-                          "x",
-                          Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes")))),
+                          "x", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes")))),
       new TestCase()
           .i(
               "x[\"claims\"][\"groups\"][0].name == \"dummy\"\n"
@@ -498,10 +496,10 @@ public class CheckerTest {
                       Decls.newVar(
                           "x",
                           Decls.newListType(
-                              Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes"))),
+                              Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes"))),
                       Decls.newVar("y", Decls.newListType(Decls.Int))))
           .error(
-              "ERROR: <input>:1:3: found no matching overload for '_+_' applied to '(list(google.api.expr.test.v1.proto3.TestAllTypes), list(int))'\n"
+              "ERROR: <input>:1:3: found no matching overload for '_+_' applied to '(list(cel.expr.conformance.proto3.TestAllTypes), list(int))'\n"
                   + " | x + y\n"
                   + " | ..^"),
       new TestCase()
@@ -512,9 +510,9 @@ public class CheckerTest {
                       Decls.newVar(
                           "x",
                           Decls.newListType(
-                              Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes")))))
+                              Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes")))))
           .error(
-              "ERROR: <input>:1:2: found no matching overload for '_[_]' applied to '(list(google.api.expr.test.v1.proto3.TestAllTypes), uint)'\n"
+              "ERROR: <input>:1:2: found no matching overload for '_[_]' applied to '(list(cel.expr.conformance.proto3.TestAllTypes), uint)'\n"
                   + " | x[1u]\n"
                   + " | .^"),
       new TestCase()
@@ -525,17 +523,17 @@ public class CheckerTest {
                       Decls.newVar(
                           "x",
                           Decls.newListType(
-                              Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes")))))
+                              Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes")))))
           .r(
-              "_==_(_[_](_+_(x~list(google.api.expr.test.v1.proto3.TestAllTypes)^x,\n"
-                  + "                x~list(google.api.expr.test.v1.proto3.TestAllTypes)^x)\n"
-                  + "            ~list(google.api.expr.test.v1.proto3.TestAllTypes)^add_list,\n"
+              "_==_(_[_](_+_(x~list(cel.expr.conformance.proto3.TestAllTypes)^x,\n"
+                  + "                x~list(cel.expr.conformance.proto3.TestAllTypes)^x)\n"
+                  + "            ~list(cel.expr.conformance.proto3.TestAllTypes)^add_list,\n"
                   + "           1~int)\n"
-                  + "       ~google.api.expr.test.v1.proto3.TestAllTypes^index_list\n"
+                  + "       ~cel.expr.conformance.proto3.TestAllTypes^index_list\n"
                   + "       .\n"
                   + "       single_int32\n"
                   + "       ~int,\n"
-                  + "      size(x~list(google.api.expr.test.v1.proto3.TestAllTypes)^x)~int^size_list)\n"
+                  + "      size(x~list(cel.expr.conformance.proto3.TestAllTypes)^x)~int^size_list)\n"
                   + "  ~bool^equals")
           .type(Decls.Bool),
       new TestCase()
@@ -544,10 +542,10 @@ public class CheckerTest {
               new env()
                   .idents(
                       Decls.newVar(
-                          "x", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes"))))
+                          "x", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes"))))
           .r(
-              "_==_(_[_](x~google.api.expr.test.v1.proto3.TestAllTypes^x.repeated_int64~list(int),\n"
-                  + "           x~google.api.expr.test.v1.proto3.TestAllTypes^x.single_int32~int)\n"
+              "_==_(_[_](x~cel.expr.conformance.proto3.TestAllTypes^x.repeated_int64~list(int),\n"
+                  + "           x~cel.expr.conformance.proto3.TestAllTypes^x.single_int32~int)\n"
                   + "       ~int^index_list,\n"
                   + "      23~int)\n"
                   + "  ~bool^equals")
@@ -558,10 +556,10 @@ public class CheckerTest {
               new env()
                   .idents(
                       Decls.newVar(
-                          "x", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes"))))
+                          "x", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes"))))
           .r(
-              "_==_(size(x~google.api.expr.test.v1.proto3.TestAllTypes^x.map_int64_nested_type\n"
-                  + "            ~map(int, google.api.expr.test.v1.proto3.NestedTestAllTypes))\n"
+              "_==_(size(x~cel.expr.conformance.proto3.TestAllTypes^x.map_int64_nested_type\n"
+                  + "            ~map(int, cel.expr.conformance.proto3.NestedTestAllTypes))\n"
                   + "       ~int^size_map,\n"
                   + "      0~int)\n"
                   + "  ~bool^equals")
@@ -603,13 +601,13 @@ public class CheckerTest {
               new env()
                   .idents(
                       Decls.newVar(
-                          "x", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes"))))
+                          "x", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes"))))
           .r(
               "__comprehension__(\n"
                   + "// Variable\n"
                   + "x,\n"
                   + "// Target\n"
-                  + "x~google.api.expr.test.v1.proto3.TestAllTypes^x.repeated_int64~list(int),\n"
+                  + "x~cel.expr.conformance.proto3.TestAllTypes^x.repeated_int64~list(int),\n"
                   + "// Accumulator\n"
                   + "__result__,\n"
                   + "// Init\n"
@@ -634,13 +632,13 @@ public class CheckerTest {
               new env()
                   .idents(
                       Decls.newVar(
-                          "x", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes"))))
+                          "x", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes"))))
           .r(
               "__comprehension__(\n"
                   + "// Variable\n"
                   + "x,\n"
                   + "// Target\n"
-                  + "x~google.api.expr.test.v1.proto3.TestAllTypes^x.repeated_int64~list(int),\n"
+                  + "x~cel.expr.conformance.proto3.TestAllTypes^x.repeated_int64~list(int),\n"
                   + "// Accumulator\n"
                   + "__result__,\n"
                   + "// Init\n"
@@ -675,9 +673,9 @@ public class CheckerTest {
                           "x",
                           Decls.newMapType(
                               Decls.String,
-                              Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes")))))
+                              Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes")))))
           .error(
-              "ERROR: <input>:1:2: found no matching overload for '_[_]' applied to '(map(string, google.api.expr.test.v1.proto3.TestAllTypes), int)'\n"
+              "ERROR: <input>:1:2: found no matching overload for '_[_]' applied to '(map(string, cel.expr.conformance.proto3.TestAllTypes), int)'\n"
                   + " | x[2].single_int32 == 23\n"
                   + " | .^"),
       new TestCase()
@@ -689,10 +687,10 @@ public class CheckerTest {
                           "x",
                           Decls.newMapType(
                               Decls.String,
-                              Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes")))))
+                              Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes")))))
           .r(
-              "_==_(_[_](x~map(string, google.api.expr.test.v1.proto3.TestAllTypes)^x, \"a\"~string)\n"
-                  + "~google.api.expr.test.v1.proto3.TestAllTypes^index_map\n"
+              "_==_(_[_](x~map(string, cel.expr.conformance.proto3.TestAllTypes)^x, \"a\"~string)\n"
+                  + "~cel.expr.conformance.proto3.TestAllTypes^index_map\n"
                   + ".\n"
                   + "single_int32\n"
                   + "~int,\n"
@@ -705,15 +703,15 @@ public class CheckerTest {
               new env()
                   .idents(
                       Decls.newVar(
-                          "x", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes"))))
+                          "x", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes"))))
           // Our implementation code is expanding the macro
           .r(
               "_&&_(\n"
                   + "  _==_(\n"
-                  + "    x~google.api.expr.test.v1.proto3.TestAllTypes^x.single_nested_message~google.api.expr.test.v1.proto3.TestAllTypes.NestedMessage.bb~int,\n"
+                  + "    x~cel.expr.conformance.proto3.TestAllTypes^x.single_nested_message~cel.expr.conformance.proto3.TestAllTypes.NestedMessage.bb~int,\n"
                   + "    43~int\n"
                   + "  )~bool^equals,\n"
-                  + "  x~google.api.expr.test.v1.proto3.TestAllTypes^x.single_nested_message~test-only~~bool\n"
+                  + "  x~cel.expr.conformance.proto3.TestAllTypes^x.single_nested_message~test-only~~bool\n"
                   + ")~bool^logical_and")
           .type(Decls.Bool),
       new TestCase()
@@ -723,7 +721,7 @@ public class CheckerTest {
               new env()
                   .idents(
                       Decls.newVar(
-                          "x", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes"))))
+                          "x", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes"))))
           .error(
               "ERROR: <input>:1:24: undefined field 'undefined'\n"
                   + " | x.single_nested_message.undefined == x.undefined && has(x.single_int32) && has(x.repeated_int32)\n"
@@ -737,10 +735,10 @@ public class CheckerTest {
               new env()
                   .idents(
                       Decls.newVar(
-                          "x", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes"))))
+                          "x", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes"))))
           .r(
-              "_!=_(x~google.api.expr.test.v1.proto3.TestAllTypes^x.single_nested_message\n"
-                  + "~google.api.expr.test.v1.proto3.TestAllTypes.NestedMessage,\n"
+              "_!=_(x~cel.expr.conformance.proto3.TestAllTypes^x.single_nested_message\n"
+                  + "~cel.expr.conformance.proto3.TestAllTypes.NestedMessage,\n"
                   + "null~null)\n"
                   + "~bool^not_equals")
           .type(Decls.Bool),
@@ -750,9 +748,9 @@ public class CheckerTest {
               new env()
                   .idents(
                       Decls.newVar(
-                          "x", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes"))))
+                          "x", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes"))))
           .r(
-              "_!=_(x~google.api.expr.test.v1.proto3.TestAllTypes^x.single_int64~int,null~null)~bool^not_equals")
+              "_!=_(x~cel.expr.conformance.proto3.TestAllTypes^x.single_int64~int,null~null)~bool^not_equals")
           .type(Decls.Bool),
       new TestCase()
           .i("x.single_int64_wrapper == null")
@@ -760,9 +758,9 @@ public class CheckerTest {
               new env()
                   .idents(
                       Decls.newVar(
-                          "x", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes"))))
+                          "x", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes"))))
           .r(
-              "_==_(x~google.api.expr.test.v1.proto3.TestAllTypes^x.single_int64_wrapper\n"
+              "_==_(x~cel.expr.conformance.proto3.TestAllTypes^x.single_int64_wrapper\n"
                   + "~wrapper(int),\n"
                   + "null~null)\n"
                   + "~bool^equals")
@@ -782,30 +780,30 @@ public class CheckerTest {
               new env()
                   .idents(
                       Decls.newVar(
-                          "x", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes"))))
+                          "x", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes"))))
           .r(
               "_&&_(\n"
                   + "	_&&_(\n"
                   + "		_&&_(\n"
                   + "		_&&_(\n"
-                  + "			x~google.api.expr.test.v1.proto3.TestAllTypes^x.single_bool_wrapper~wrapper(bool),\n"
+                  + "			x~cel.expr.conformance.proto3.TestAllTypes^x.single_bool_wrapper~wrapper(bool),\n"
                   + "			_==_(\n"
-                  + "			x~google.api.expr.test.v1.proto3.TestAllTypes^x.single_bytes_wrapper~wrapper(bytes),\n"
+                  + "			x~cel.expr.conformance.proto3.TestAllTypes^x.single_bytes_wrapper~wrapper(bytes),\n"
                   + "			b\"hi\"~bytes\n"
                   + "			)~bool^equals\n"
                   + "		)~bool^logical_and,\n"
                   + "		_!=_(\n"
-                  + "			x~google.api.expr.test.v1.proto3.TestAllTypes^x.single_double_wrapper~wrapper(double),\n"
+                  + "			x~cel.expr.conformance.proto3.TestAllTypes^x.single_double_wrapper~wrapper(double),\n"
                   + "			2.0~double\n"
                   + "		)~bool^not_equals\n"
                   + "		)~bool^logical_and,\n"
                   + "		_&&_(\n"
                   + "		_==_(\n"
-                  + "			x~google.api.expr.test.v1.proto3.TestAllTypes^x.single_float_wrapper~wrapper(double),\n"
+                  + "			x~cel.expr.conformance.proto3.TestAllTypes^x.single_float_wrapper~wrapper(double),\n"
                   + "			1.0~double\n"
                   + "		)~bool^equals,\n"
                   + "		_!=_(\n"
-                  + "			x~google.api.expr.test.v1.proto3.TestAllTypes^x.single_int32_wrapper~wrapper(int),\n"
+                  + "			x~cel.expr.conformance.proto3.TestAllTypes^x.single_int32_wrapper~wrapper(int),\n"
                   + "			2~int\n"
                   + "		)~bool^not_equals\n"
                   + "		)~bool^logical_and\n"
@@ -813,21 +811,21 @@ public class CheckerTest {
                   + "	_&&_(\n"
                   + "		_&&_(\n"
                   + "		_==_(\n"
-                  + "			x~google.api.expr.test.v1.proto3.TestAllTypes^x.single_int64_wrapper~wrapper(int),\n"
+                  + "			x~cel.expr.conformance.proto3.TestAllTypes^x.single_int64_wrapper~wrapper(int),\n"
                   + "			1~int\n"
                   + "		)~bool^equals,\n"
                   + "		_==_(\n"
-                  + "			x~google.api.expr.test.v1.proto3.TestAllTypes^x.single_string_wrapper~wrapper(string),\n"
+                  + "			x~cel.expr.conformance.proto3.TestAllTypes^x.single_string_wrapper~wrapper(string),\n"
                   + "			\"hi\"~string\n"
                   + "		)~bool^equals\n"
                   + "		)~bool^logical_and,\n"
                   + "		_&&_(\n"
                   + "		_==_(\n"
-                  + "			x~google.api.expr.test.v1.proto3.TestAllTypes^x.single_uint32_wrapper~wrapper(uint),\n"
+                  + "			x~cel.expr.conformance.proto3.TestAllTypes^x.single_uint32_wrapper~wrapper(uint),\n"
                   + "			1u~uint\n"
                   + "		)~bool^equals,\n"
                   + "		_!=_(\n"
-                  + "			x~google.api.expr.test.v1.proto3.TestAllTypes^x.single_uint64_wrapper~wrapper(uint),\n"
+                  + "			x~cel.expr.conformance.proto3.TestAllTypes^x.single_uint64_wrapper~wrapper(uint),\n"
                   + "			42u~uint\n"
                   + "		)~bool^not_equals\n"
                   + "		)~bool^logical_and\n"
@@ -850,7 +848,7 @@ public class CheckerTest {
               new env()
                   .idents(
                       Decls.newVar(
-                          "x", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes"))))
+                          "x", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes"))))
           .type(Decls.Bool),
       new TestCase()
           .i(
@@ -866,7 +864,7 @@ public class CheckerTest {
               new env()
                   .idents(
                       Decls.newVar(
-                          "x", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes"))))
+                          "x", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes"))))
           .type(Decls.Bool),
       new TestCase()
           .i("x.repeated_int64.exists(y, y > 10) && y < 5")
@@ -874,7 +872,7 @@ public class CheckerTest {
               new env()
                   .idents(
                       Decls.newVar(
-                          "x", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes"))))
+                          "x", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes"))))
           .error(
               "ERROR: <input>:1:39: undeclared reference to 'y' (in container '')\n"
                   + " | x.repeated_int64.exists(y, y > 10) && y < 5\n"
@@ -886,7 +884,7 @@ public class CheckerTest {
               new env()
                   .idents(
                       Decls.newVar(
-                          "x", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes"))))
+                          "x", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes"))))
           .r(
               "_&&_(\n"
                   + "\t\t\t_&&_(\n"
@@ -894,7 +892,7 @@ public class CheckerTest {
                   + "\t\t\t\t// Variable\n"
                   + "\t\t\t\te,\n"
                   + "\t\t\t\t// Target\n"
-                  + "\t\t\t\tx~google.api.expr.test.v1.proto3.TestAllTypes^x.repeated_int64~list(int),\n"
+                  + "\t\t\t\tx~cel.expr.conformance.proto3.TestAllTypes^x.repeated_int64~list(int),\n"
                   + "\t\t\t\t// Accumulator\n"
                   + "\t\t\t\t__result__,\n"
                   + "\t\t\t\t// Init\n"
@@ -917,7 +915,7 @@ public class CheckerTest {
                   + "\t\t\t\t// Variable\n"
                   + "\t\t\t\te,\n"
                   + "\t\t\t\t// Target\n"
-                  + "\t\t\t\tx~google.api.expr.test.v1.proto3.TestAllTypes^x.repeated_int64~list(int),\n"
+                  + "\t\t\t\tx~cel.expr.conformance.proto3.TestAllTypes^x.repeated_int64~list(int),\n"
                   + "\t\t\t\t// Accumulator\n"
                   + "\t\t\t\t__result__,\n"
                   + "\t\t\t\t// Init\n"
@@ -943,7 +941,7 @@ public class CheckerTest {
                   + "\t\t\t  // Variable\n"
                   + "\t\t\t  e,\n"
                   + "\t\t\t  // Target\n"
-                  + "\t\t\t  x~google.api.expr.test.v1.proto3.TestAllTypes^x.repeated_int64~list(int),\n"
+                  + "\t\t\t  x~cel.expr.conformance.proto3.TestAllTypes^x.repeated_int64~list(int),\n"
                   + "\t\t\t  // Accumulator\n"
                   + "\t\t\t  __result__,\n"
                   + "\t\t\t  // Init\n"
@@ -975,9 +973,9 @@ public class CheckerTest {
               new env()
                   .idents(
                       Decls.newVar(
-                          "x", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes"))))
+                          "x", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes"))))
           .error(
-              "ERROR: <input>:1:1: expression of type 'google.api.expr.test.v1.proto3.TestAllTypes' cannot be range of a comprehension (must be list, map, or dynamic)\n"
+              "ERROR: <input>:1:1: expression of type 'cel.expr.conformance.proto3.TestAllTypes' cannot be range of a comprehension (must be list, map, or dynamic)\n"
                   + " | x.all(e, 0)\n"
                   + " | ^\n"
                   + "ERROR: <input>:1:6: found no matching overload for '_&&_' applied to '(bool, int)'\n"
@@ -1016,24 +1014,20 @@ public class CheckerTest {
           .type(Decls.newListType(Decls.Dyn))
           .env(new env().idents(Decls.newVar("lists", Decls.Dyn))),
       new TestCase()
-          .i("google.api.expr.test.v1.proto3.TestAllTypes")
+          .i("cel.expr.conformance.proto3.TestAllTypes")
           .r(
-              "google.api.expr.test.v1.proto3.TestAllTypes\n"
-                  + "\t~type(google.api.expr.test.v1.proto3.TestAllTypes)\n"
-                  + "\t^google.api.expr.test.v1.proto3.TestAllTypes")
-          .type(
-              Decls.newTypeType(
-                  Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes"))),
+              "cel.expr.conformance.proto3.TestAllTypes\n"
+                  + "\t~type(cel.expr.conformance.proto3.TestAllTypes)\n"
+                  + "\t^cel.expr.conformance.proto3.TestAllTypes")
+          .type(Decls.newTypeType(Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes"))),
       new TestCase()
           .i("proto3.TestAllTypes")
-          .container("google.api.expr.test.v1")
+          .container("cel.expr.conformance")
           .r(
-              "google.api.expr.test.v1.proto3.TestAllTypes\n"
-                  + "\t~type(google.api.expr.test.v1.proto3.TestAllTypes)\n"
-                  + "\t^google.api.expr.test.v1.proto3.TestAllTypes")
-          .type(
-              Decls.newTypeType(
-                  Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes"))),
+              "cel.expr.conformance.proto3.TestAllTypes\n"
+                  + "\t~type(cel.expr.conformance.proto3.TestAllTypes)\n"
+                  + "\t^cel.expr.conformance.proto3.TestAllTypes")
+          .type(Decls.newTypeType(Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes"))),
       new TestCase()
           .i("1 + x")
           .error(
@@ -1043,9 +1037,9 @@ public class CheckerTest {
       new TestCase()
           .i(
               "x == google.protobuf.Any{\n"
-                  + "\t\t\t\ttype_url:'types.googleapis.com/google.api.expr.test.v1.proto3.TestAllTypes'\n"
+                  + "\t\t\t\ttype_url:'types.googleapis.com/cel.expr.conformance.proto3.TestAllTypes'\n"
                   + "\t\t\t} && x.single_nested_message.bb == 43\n"
-                  + "\t\t\t|| x == google.api.expr.test.v1.proto3.TestAllTypes{}\n"
+                  + "\t\t\t|| x == cel.expr.conformance.proto3.TestAllTypes{}\n"
                   + "\t\t\t|| y < x\n"
                   + "\t\t\t|| x >= x")
           .env(
@@ -1060,7 +1054,7 @@ public class CheckerTest {
                   + "\t\t\t_==_(\n"
                   + "\t\t\t\tx~any^x,\n"
                   + "\t\t\t\tgoogle.protobuf.Any{\n"
-                  + "\t\t\t\t\ttype_url:\"types.googleapis.com/google.api.expr.test.v1.proto3.TestAllTypes\"~string\n"
+                  + "\t\t\t\t\ttype_url:\"types.googleapis.com/cel.expr.conformance.proto3.TestAllTypes\"~string\n"
                   + "\t\t\t\t}~any^google.protobuf.Any\n"
                   + "\t\t\t)~bool^equals,\n"
                   + "\t\t\t_==_(\n"
@@ -1070,7 +1064,7 @@ public class CheckerTest {
                   + "\t\t)~bool^logical_and,\n"
                   + "\t\t_==_(\n"
                   + "\t\t\tx~any^x,\n"
-                  + "\t\t\tgoogle.api.expr.test.v1.proto3.TestAllTypes{}~google.api.expr.test.v1.proto3.TestAllTypes^google.api.expr.test.v1.proto3.TestAllTypes\n"
+                  + "\t\t\tcel.expr.conformance.proto3.TestAllTypes{}~cel.expr.conformance.proto3.TestAllTypes^cel.expr.conformance.proto3.TestAllTypes\n"
                   + "\t\t)~bool^equals\n"
                   + "\t)~bool^logical_or,\n"
                   + "\t_||_(\n"
@@ -1093,9 +1087,9 @@ public class CheckerTest {
                   .idents(
                       Decls.newVar(
                           "container.x",
-                          Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes"))))
-          .r("container.x~google.api.expr.test.v1.proto3.TestAllTypes^container.x")
-          .type(Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes")),
+                          Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes"))))
+          .r("container.x~cel.expr.conformance.proto3.TestAllTypes^container.x")
+          .type(Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes")),
       new TestCase()
           .i("list == .type([1]) && map == .type({1:2u})")
           .r(
@@ -1144,15 +1138,14 @@ public class CheckerTest {
               new env()
                   .idents(
                       Decls.newVar(
-                          "x", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes")))
+                          "x", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes")))
                   .functions(
                       Decls.newFunction(
                           "size",
                           Decls.newOverload(
                               "size_message",
                               singletonList(
-                                  Decls.newObjectType(
-                                      "google.api.expr.test.v1.proto3.TestAllTypes")),
+                                  Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes")),
                               Decls.Int))))
           .type(Decls.Bool),
       new TestCase()
@@ -1161,9 +1154,9 @@ public class CheckerTest {
               new env()
                   .idents(
                       Decls.newVar(
-                          "x", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes"))))
+                          "x", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes"))))
           .r(
-              "_!=_(_+_(x~google.api.expr.test.v1.proto3.TestAllTypes^x.single_int64_wrapper\n"
+              "_!=_(_+_(x~cel.expr.conformance.proto3.TestAllTypes^x.single_int64_wrapper\n"
                   + "~wrapper(int),\n"
                   + "1~int)\n"
                   + "~int^add_int64,\n"
@@ -1176,12 +1169,12 @@ public class CheckerTest {
               new env()
                   .idents(
                       Decls.newVar(
-                          "x", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes")),
+                          "x", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes")),
                       Decls.newVar("y", Decls.newObjectType("google.protobuf.Int32Value"))))
           .r(
               "_!=_(\n"
                   + "\t_+_(\n"
-                  + "\t  x~google.api.expr.test.v1.proto3.TestAllTypes^x.single_int64_wrapper~wrapper(int),\n"
+                  + "\t  x~cel.expr.conformance.proto3.TestAllTypes^x.single_int64_wrapper~wrapper(int),\n"
                   + "\t  y~wrapper(int)^y\n"
                   + "\t)~int^add_int64,\n"
                   + "\t23~int\n"
@@ -1449,63 +1442,59 @@ public class CheckerTest {
               new env()
                   .idents(
                       Decls.newVar(
-                          "pb2",
-                          Decls.newObjectType("google.api.expr.test.v1.proto2.TestAllTypes")),
+                          "pb2", Decls.newObjectType("cel.expr.conformance.proto2.TestAllTypes")),
                       Decls.newVar(
-                          "pb3",
-                          Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes"))))
+                          "pb3", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes"))))
           .r(
               "_&&_(\n"
                   + "\t_&&_(\n"
                   + "\t  _&&_(\n"
                   + "\t\t!_(\n"
-                  + "\t\t  pb2~google.api.expr.test.v1.proto2.TestAllTypes^pb2.single_int64~test-only~~bool\n"
+                  + "\t\t  pb2~cel.expr.conformance.proto2.TestAllTypes^pb2.single_int64~test-only~~bool\n"
                   + "\t\t)~bool^logical_not,\n"
                   + "\t\t!_(\n"
-                  + "\t\t  pb2~google.api.expr.test.v1.proto2.TestAllTypes^pb2.repeated_int32~test-only~~bool\n"
+                  + "\t\t  pb2~cel.expr.conformance.proto2.TestAllTypes^pb2.repeated_int32~test-only~~bool\n"
                   + "\t\t)~bool^logical_not\n"
                   + "\t  )~bool^logical_and,\n"
                   + "\t  !_(\n"
-                  + "\t\tpb2~google.api.expr.test.v1.proto2.TestAllTypes^pb2.map_string_string~test-only~~bool\n"
+                  + "\t\tpb2~cel.expr.conformance.proto2.TestAllTypes^pb2.map_string_string~test-only~~bool\n"
                   + "\t  )~bool^logical_not\n"
                   + "\t)~bool^logical_and,\n"
                   + "\t_&&_(\n"
                   + "\t  _&&_(\n"
                   + "\t\t!_(\n"
-                  + "\t\t  pb3~google.api.expr.test.v1.proto3.TestAllTypes^pb3.single_int64~test-only~~bool\n"
+                  + "\t\t  pb3~cel.expr.conformance.proto3.TestAllTypes^pb3.single_int64~test-only~~bool\n"
                   + "\t\t)~bool^logical_not,\n"
                   + "\t\t!_(\n"
-                  + "\t\t  pb3~google.api.expr.test.v1.proto3.TestAllTypes^pb3.repeated_int32~test-only~~bool\n"
+                  + "\t\t  pb3~cel.expr.conformance.proto3.TestAllTypes^pb3.repeated_int32~test-only~~bool\n"
                   + "\t\t)~bool^logical_not\n"
                   + "\t  )~bool^logical_and,\n"
                   + "\t  !_(\n"
-                  + "\t\tpb3~google.api.expr.test.v1.proto3.TestAllTypes^pb3.map_string_string~test-only~~bool\n"
+                  + "\t\tpb3~cel.expr.conformance.proto3.TestAllTypes^pb3.map_string_string~test-only~~bool\n"
                   + "\t  )~bool^logical_not\n"
                   + "\t)~bool^logical_and\n"
                   + "  )~bool^logical_and")
           .type(Decls.Bool),
       new TestCase()
           .i("TestAllTypes{}.repeated_nested_message")
-          .container("google.api.expr.test.v1.proto2")
+          .container("cel.expr.conformance.proto2")
           .r(
-              "google.api.expr.test.v1.proto2.TestAllTypes{}~google.api.expr.test.v1.proto2.TestAllTypes^\n"
-                  + "\t\tgoogle.api.expr.test.v1.proto2.TestAllTypes.repeated_nested_message\n"
-                  + "\t\t~list(google.api.expr.test.v1.proto2.TestAllTypes.NestedMessage)")
+              "cel.expr.conformance.proto2.TestAllTypes{}~cel.expr.conformance.proto2.TestAllTypes^\n"
+                  + "\t\tcel.expr.conformance.proto2.TestAllTypes.repeated_nested_message\n"
+                  + "\t\t~list(cel.expr.conformance.proto2.TestAllTypes.NestedMessage)")
           .type(
               Decls.newListType(
-                  Decls.newObjectType(
-                      "google.api.expr.test.v1.proto2.TestAllTypes.NestedMessage"))),
+                  Decls.newObjectType("cel.expr.conformance.proto2.TestAllTypes.NestedMessage"))),
       new TestCase()
           .i("TestAllTypes{}.repeated_nested_message")
-          .container("google.api.expr.test.v1.proto3")
+          .container("cel.expr.conformance.proto3")
           .r(
-              "google.api.expr.test.v1.proto3.TestAllTypes{}~google.api.expr.test.v1.proto3.TestAllTypes^\n"
-                  + "\t\tgoogle.api.expr.test.v1.proto3.TestAllTypes.repeated_nested_message\n"
-                  + "\t\t~list(google.api.expr.test.v1.proto3.TestAllTypes.NestedMessage)")
+              "cel.expr.conformance.proto3.TestAllTypes{}~cel.expr.conformance.proto3.TestAllTypes^\n"
+                  + "\t\tcel.expr.conformance.proto3.TestAllTypes.repeated_nested_message\n"
+                  + "\t\t~list(cel.expr.conformance.proto3.TestAllTypes.NestedMessage)")
           .type(
               Decls.newListType(
-                  Decls.newObjectType(
-                      "google.api.expr.test.v1.proto3.TestAllTypes.NestedMessage"))),
+                  Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes.NestedMessage"))),
       new TestCase()
           .i("base64.encode('hello')")
           .env(
@@ -1545,8 +1534,8 @@ public class CheckerTest {
 
     TypeRegistry reg =
         ProtoTypeRegistry.newRegistry(
-            com.google.api.expr.test.v1.proto2.TestAllTypesProto.TestAllTypes.getDefaultInstance(),
-            com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes.getDefaultInstance());
+            dev.cel.expr.conformance.proto2.TestAllTypes.getDefaultInstance(),
+            dev.cel.expr.conformance.proto3.TestAllTypes.getDefaultInstance());
     Container cont = Container.newContainer(Container.name(tc.container));
     CheckerEnv env = newStandardCheckerEnv(cont, reg);
     if (tc.disableStdEnv) {

--- a/core/src/test/java/org/projectnessie/cel/common/types/ProviderTest.java
+++ b/core/src/test/java/org/projectnessie/cel/common/types/ProviderTest.java
@@ -36,8 +36,6 @@ import static org.projectnessie.cel.common.types.UintT.uintOf;
 import static org.projectnessie.cel.common.types.pb.ProtoTypeRegistry.newEmptyRegistry;
 import static org.projectnessie.cel.common.types.pb.ProtoTypeRegistry.newRegistry;
 
-import com.google.api.expr.test.v1.proto3.TestAllTypesProto.GlobalEnum;
-import com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes;
 import com.google.api.expr.v1alpha1.CheckedExpr;
 import com.google.api.expr.v1alpha1.Constant;
 import com.google.api.expr.v1alpha1.Expr;
@@ -55,6 +53,8 @@ import com.google.protobuf.StringValue;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.UInt32Value;
 import com.google.protobuf.UInt64Value;
+import dev.cel.expr.conformance.proto3.GlobalEnum;
+import dev.cel.expr.conformance.proto3.TestAllTypes;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
@@ -105,10 +105,10 @@ public class ProviderTest {
     reg.registerDescriptor(GlobalEnum.getDescriptor().getFile());
     reg.registerDescriptor(OutOfOrderEnumOuterClass.getDescriptor().getFile());
 
-    Val enumVal = reg.enumValue("google.api.expr.test.v1.proto3.GlobalEnum.GOO");
+    Val enumVal = reg.enumValue("cel.expr.conformance.proto3.GlobalEnum.GOO");
     assertThat(enumVal).extracting(Val::intValue).isEqualTo((long) GlobalEnum.GOO.getNumber());
 
-    Val enumVal2 = reg.findIdent("google.api.expr.test.v1.proto3.GlobalEnum.GOO");
+    Val enumVal2 = reg.findIdent("cel.expr.conformance.proto3.GlobalEnum.GOO");
     assertThat(enumVal2.equal(enumVal)).isSameAs(True);
 
     // Previously, we checked `getIndex` on the `EnumValueDescriptor`, which is the same as the
@@ -140,7 +140,7 @@ public class ProviderTest {
     ProtoTypeRegistry reg = newEmptyRegistry();
     reg.registerDescriptor(GlobalEnum.getDescriptor().getFile());
 
-    String msgTypeName = "google.api.expr.test.v1.proto3.TestAllTypes";
+    String msgTypeName = "cel.expr.conformance.proto3.TestAllTypes";
     assertThat(reg.findType(msgTypeName)).isNotNull();
     // assertThat(reg.findType(msgTypeName + "Undefined")).isNotNull(); ... this doesn't exist in
     // protobuf-java
@@ -198,8 +198,7 @@ public class ProviderTest {
     TypeRegistry reg = newRegistry(TestAllTypes.getDefaultInstance());
     Val exp =
         reg.newValue(
-            "google.api.expr.test.v1.proto3.TestAllTypes",
-            mapOf("single_int32_wrapper", intOf(123)));
+            "cel.expr.conformance.proto3.TestAllTypes", mapOf("single_int32_wrapper", intOf(123)));
     assertThat(exp).matches(v -> !Err.isError(v));
     TestAllTypes ce = exp.convertToNative(TestAllTypes.class);
     assertThat(ce)

--- a/core/src/test/java/org/projectnessie/cel/common/types/pb/FieldDescriptionTest.java
+++ b/core/src/test/java/org/projectnessie/cel/common/types/pb/FieldDescriptionTest.java
@@ -22,10 +22,6 @@ import static org.projectnessie.cel.common.types.StringT.stringOf;
 import static org.projectnessie.cel.common.types.UintT.uintOf;
 import static org.projectnessie.cel.common.types.pb.Db.newDb;
 
-import com.google.api.expr.test.v1.proto3.TestAllTypesProto.NestedTestAllTypes;
-import com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes;
-import com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes.NestedEnum;
-import com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes.NestedMessage;
 import com.google.api.expr.v1alpha1.Type;
 import com.google.protobuf.BoolValue;
 import com.google.protobuf.Duration;
@@ -36,6 +32,10 @@ import com.google.protobuf.NullValue;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.Value;
+import dev.cel.expr.conformance.proto3.NestedTestAllTypes;
+import dev.cel.expr.conformance.proto3.TestAllTypes;
+import dev.cel.expr.conformance.proto3.TestAllTypes.NestedEnum;
+import dev.cel.expr.conformance.proto3.TestAllTypes.NestedMessage;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
@@ -69,7 +69,7 @@ public class FieldDescriptionTest {
     // matches the one determined by the TypeDescription utils.
     Type got = fd.checkedType();
     Type wanted =
-        Type.newBuilder().setMessageType("google.api.expr.test.v1.proto3.TestAllTypes").build();
+        Type.newBuilder().setMessageType("cel.expr.conformance.proto3.TestAllTypes").build();
     assertThat(got).isEqualTo(wanted);
   }
 

--- a/core/src/test/java/org/projectnessie/cel/common/types/pb/PbTypeDescriptionTest.java
+++ b/core/src/test/java/org/projectnessie/cel/common/types/pb/PbTypeDescriptionTest.java
@@ -19,8 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.projectnessie.cel.Util.mapOf;
 import static org.projectnessie.cel.common.types.pb.Db.newDb;
 
-import com.google.api.expr.test.v1.proto3.TestAllTypesProto.NestedTestAllTypes;
-import com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes;
 import com.google.api.expr.v1alpha1.Type;
 import com.google.protobuf.Any;
 import com.google.protobuf.BoolValue;
@@ -41,6 +39,8 @@ import com.google.protobuf.Timestamp;
 import com.google.protobuf.UInt32Value;
 import com.google.protobuf.UInt64Value;
 import com.google.protobuf.Value;
+import dev.cel.expr.conformance.proto3.NestedTestAllTypes;
+import dev.cel.expr.conformance.proto3.TestAllTypes;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Map;
@@ -232,7 +232,7 @@ public class PbTypeDescriptionTest {
     assertThat(field).isNotNull();
     Type listType =
         Decls.newListType(
-            Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes.NestedMessage"));
+            Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes.NestedMessage"));
     assertThat(field.checkedType()).isEqualTo(listType);
   }
 

--- a/core/src/test/java/org/projectnessie/cel/common/types/pb/UnwrapContext.java
+++ b/core/src/test/java/org/projectnessie/cel/common/types/pb/UnwrapContext.java
@@ -18,7 +18,7 @@ package org.projectnessie.cel.common.types.pb;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.projectnessie.cel.common.types.pb.Db.newDb;
 
-import com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes;
+import dev.cel.expr.conformance.proto3.TestAllTypes;
 
 /** Required by {@link UnwrapTestCase} et al. */
 class UnwrapContext {

--- a/core/src/test/java/org/projectnessie/cel/common/types/pb/UnwrapTestCase.java
+++ b/core/src/test/java/org/projectnessie/cel/common/types/pb/UnwrapTestCase.java
@@ -15,7 +15,6 @@
  */
 package org.projectnessie.cel.common.types.pb;
 
-import com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes;
 import com.google.protobuf.BoolValue;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.BytesValue;
@@ -33,6 +32,7 @@ import com.google.protobuf.Timestamp;
 import com.google.protobuf.UInt32Value;
 import com.google.protobuf.UInt64Value;
 import com.google.protobuf.Value;
+import dev.cel.expr.conformance.proto3.TestAllTypes;
 import java.util.function.Supplier;
 
 /**

--- a/core/src/test/java/org/projectnessie/cel/interpreter/AttributesTest.java
+++ b/core/src/test/java/org/projectnessie/cel/interpreter/AttributesTest.java
@@ -42,11 +42,11 @@ import static org.projectnessie.cel.interpreter.Interpreter.newStandardInterpret
 import static org.projectnessie.cel.interpreter.Interpreter.optimize;
 import static org.projectnessie.cel.interpreter.Interpreter.trackState;
 
-import com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes;
-import com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes.NestedMessage;
 import com.google.api.expr.v1alpha1.Decl;
 import com.google.api.expr.v1alpha1.Type;
 import com.google.protobuf.Any;
+import dev.cel.expr.conformance.proto3.TestAllTypes;
+import dev.cel.expr.conformance.proto3.TestAllTypes.NestedMessage;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -378,9 +378,9 @@ class AttributesTest {
     AttributeFactory attrs = newAttributeFactory(Container.defaultContainer, reg, reg);
     Activation vars = newActivation(mapOf("msg", msg));
     NamespacedAttribute attr = attrs.absoluteAttribute(1, "msg");
-    Type opType = reg.findType("google.api.expr.test.v1.proto3.TestAllTypes");
+    Type opType = reg.findType("cel.expr.conformance.proto3.TestAllTypes");
     assertThat(opType).isNotNull();
-    Type fieldType = reg.findType("google.api.expr.test.v1.proto3.TestAllTypes.NestedMessage");
+    Type fieldType = reg.findType("cel.expr.conformance.proto3.TestAllTypes.NestedMessage");
     assertThat(fieldType).isNotNull();
     attr.addQualifier(makeQualifier(attrs, opType.getType(), 2, "single_nested_message"));
     attr.addQualifier(makeQualifier(attrs, fieldType.getType(), 3, "bb"));
@@ -398,7 +398,7 @@ class AttributesTest {
     Qualifier qualBB =
         attrs.newQualifier(
             Type.newBuilder()
-                .setMessageType("google.api.expr.test.v1.proto3.TestAllTypes.NestedMessage")
+                .setMessageType("cel.expr.conformance.proto3.TestAllTypes.NestedMessage")
                 .build(),
             2,
             "bb");
@@ -421,7 +421,7 @@ class AttributesTest {
     attr.addQualifier(field);
     assertThatThrownBy(() -> attr.resolve(vars))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessage("unknown type 'google.api.expr.test.v1.proto3.TestAllTypes'");
+        .hasMessage("unknown type 'cel.expr.conformance.proto3.TestAllTypes'");
   }
 
   @Test
@@ -613,7 +613,7 @@ class AttributesTest {
     Qualifier qualBB =
         attrs.newQualifier(
             Type.newBuilder()
-                .setMessageType("google.api.expr.test.v1.proto3.TestAllTypes.NestedMessage")
+                .setMessageType("cel.expr.conformance.proto3.TestAllTypes.NestedMessage")
                 .build(),
             2,
             "bb");
@@ -633,7 +633,7 @@ class AttributesTest {
     public Qualifier newQualifier(Type objType, long qualID, Object val) {
       if (objType
           .getMessageType()
-          .equals("google.api.expr.test.v1.proto3.TestAllTypes.NestedMessage")) {
+          .equals("cel.expr.conformance.proto3.TestAllTypes.NestedMessage")) {
         return new NestedMsgQualifier(qualID, (String) val);
       }
       return af.newQualifier(objType, qualID, val);

--- a/core/src/test/java/org/projectnessie/cel/interpreter/InterpreterTest.java
+++ b/core/src/test/java/org/projectnessie/cel/interpreter/InterpreterTest.java
@@ -61,7 +61,6 @@ import static org.projectnessie.cel.interpreter.Interpreter.optimize;
 import static org.projectnessie.cel.interpreter.Interpreter.trackState;
 import static org.projectnessie.cel.interpreter.functions.Overload.standardOverloads;
 
-import com.google.api.expr.test.v1.proto2.TestAllTypesProto.TestAllTypes;
 import com.google.api.expr.v1alpha1.Constant;
 import com.google.api.expr.v1alpha1.Decl;
 import com.google.api.expr.v1alpha1.Expr;
@@ -75,6 +74,7 @@ import com.google.protobuf.StringValue;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.Value;
+import dev.cel.expr.conformance.proto2.TestAllTypes;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Arrays;
@@ -373,10 +373,8 @@ class InterpreterTest {
           .out(False),
       new TestCase(InterpreterTestCase.eq_proto_different_types)
           .expr("dyn(TestAllTypes{}) == dyn(NestedTestAllTypes{})")
-          .container("google.api.expr.test.v1.proto2")
-          .types(
-              com.google.api.expr.test.v1.proto2.TestAllTypesProto.TestAllTypes
-                  .getDefaultInstance())
+          .container("cel.expr.conformance.proto2")
+          .types(dev.cel.expr.conformance.proto2.TestAllTypes.getDefaultInstance())
           .out(False),
       new TestCase(InterpreterTestCase.not_lt_dyn_big_uint_int)
           .expr("dyn(9223372036854775808u) < 1")
@@ -394,10 +392,8 @@ class InterpreterTest {
       new TestCase(InterpreterTestCase.eq_proto_nan_equal)
           .expr(
               "TestAllTypes{single_double: double('NaN')} == TestAllTypes{single_double: double('NaN')}")
-          .container("google.api.expr.test.v1.proto3")
-          .types(
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes
-                  .getDefaultInstance())
+          .container("cel.expr.conformance.proto3")
+          .types(dev.cel.expr.conformance.proto3.TestAllTypes.getDefaultInstance())
           // The outcome in the generated Java proto code is different than in the conformance-test,
           // it is NOT: "For proto equality, fields with NaN value are treated as not equal."
           .out(True),
@@ -406,10 +402,9 @@ class InterpreterTest {
           .out(True),
       new TestCase(InterpreterTestCase.literal_any)
           .expr(
-              "google.protobuf.Any{type_url: 'type.googleapis.com/google.api.expr.test.v1.proto2.TestAllTypes', value: b'\\x08\\x96\\x01'}")
+              "google.protobuf.Any{type_url: 'type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes', value: b'\\x08\\x96\\x01'}")
           .types(
-              com.google.api.expr.test.v1.proto2.TestAllTypesProto.TestAllTypes
-                  .getDefaultInstance(),
+              dev.cel.expr.conformance.proto2.TestAllTypes.getDefaultInstance(),
               Any.getDefaultInstance())
           .out(TestAllTypes.newBuilder().setSingleInt32(150).build()),
       new TestCase(InterpreterTestCase.literal_var)
@@ -418,24 +413,21 @@ class InterpreterTest {
           .types(
               Any.getDefaultInstance(),
               com.google.api.expr.v1alpha1.Value.getDefaultInstance(),
-              com.google.api.expr.test.v1.proto2.TestAllTypesProto.TestAllTypes
-                  .getDefaultInstance())
+              dev.cel.expr.conformance.proto2.TestAllTypes.getDefaultInstance())
           .in(
               "x",
               com.google.api.expr.v1alpha1.Value.newBuilder()
                   .setObjectValue(
                       Any.newBuilder()
                           .setTypeUrl(
-                              "type.googleapis.com/google.api.expr.test.v1.proto2.TestAllTypes")
+                              "type.googleapis.com/cel.expr.conformance.proto2.TestAllTypes")
                           .setValue(ByteString.copyFrom(new byte[] {8, (byte) 150, 1})))
                   .build())
           .out(TestAllTypes.newBuilder().setSingleInt32(150).build()),
       new TestCase(InterpreterTestCase.select_pb3_unset)
           .expr("TestAllTypes{}.single_struct")
-          .container("google.api.expr.test.v1.proto3")
-          .types(
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes
-                  .getDefaultInstance())
+          .container("cel.expr.conformance.proto3")
+          .types(dev.cel.expr.conformance.proto3.TestAllTypes.getDefaultInstance())
           .out(Struct.getDefaultInstance()),
       new TestCase(InterpreterTestCase.elem_in_mixed_type_list2)
           .expr("'elem' in [1u, 'str', 2, b'bytes']")
@@ -448,10 +440,8 @@ class InterpreterTest {
           .out(ULong.valueOf(123)),
       new TestCase(InterpreterTestCase.select_pb3_unset)
           .expr("TestAllTypes{}.single_struct")
-          .container("google.api.expr.test.v1.proto3")
-          .types(
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes
-                  .getDefaultInstance())
+          .container("cel.expr.conformance.proto3")
+          .types(dev.cel.expr.conformance.proto3.TestAllTypes.getDefaultInstance())
           .out(Struct.getDefaultInstance()),
       new TestCase(InterpreterTestCase.select_on_int64)
           .expr("a.pancakes")
@@ -460,37 +450,29 @@ class InterpreterTest {
           .err("no such overload: int.ref-resolve(*)")
           .unchecked(),
       new TestCase(InterpreterTestCase.select_pb3_empty_list)
-          .container("google.api.expr.test.v1.proto3")
+          .container("cel.expr.conformance.proto3")
           .expr("TestAllTypes{list_value: []}.list_value")
-          .types(
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes
-                  .getDefaultInstance())
+          .types(dev.cel.expr.conformance.proto3.TestAllTypes.getDefaultInstance())
           .out(ListValue.getDefaultInstance()),
       new TestCase(InterpreterTestCase.select_pb3_enum_big)
-          .container("google.api.expr.test.v1.proto3")
+          .container("cel.expr.conformance.proto3")
           .expr("x.standalone_enum")
-          .types(
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes
-                  .getDefaultInstance())
-          .env(
-              Decls.newVar("x", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes")))
+          .types(dev.cel.expr.conformance.proto3.TestAllTypes.getDefaultInstance())
+          .env(Decls.newVar("x", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes")))
           .in(
               "x",
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes.newBuilder()
+              dev.cel.expr.conformance.proto3.TestAllTypes.newBuilder()
                   .setStandaloneEnumValue(108)
                   .build())
           .out(intOf(108)),
       new TestCase(InterpreterTestCase.select_pb3_enum_neg)
-          .container("google.api.expr.test.v1.proto3")
+          .container("cel.expr.conformance.proto3")
           .expr("x.standalone_enum")
-          .types(
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes
-                  .getDefaultInstance())
-          .env(
-              Decls.newVar("x", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes")))
+          .types(dev.cel.expr.conformance.proto3.TestAllTypes.getDefaultInstance())
+          .env(Decls.newVar("x", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes")))
           .in(
               "x",
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes.newBuilder()
+              dev.cel.expr.conformance.proto3.TestAllTypes.newBuilder()
                   .setStandaloneEnumValue(-3)
                   .build())
           .out(intOf(-3)),
@@ -511,7 +493,7 @@ class InterpreterTest {
           .out(False),
       new TestCase(InterpreterTestCase.not_eq_list_one_element2).expr("[1] == [2]").out(False),
       new TestCase(InterpreterTestCase.parse_nest_message_literal)
-          .container("google.api.expr.test.v1.proto3")
+          .container("cel.expr.conformance.proto3")
           .expr(
               "NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: "
                   + "NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: "
@@ -519,9 +501,7 @@ class InterpreterTest {
                   + "NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: "
                   + "NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: NestedTestAllTypes{child: "
                   + "NestedTestAllTypes{payload: TestAllTypes{single_int64: 137}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}.payload.single_int64")
-          .types(
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.NestedTestAllTypes
-                  .getDefaultInstance())
+          .types(dev.cel.expr.conformance.proto3.NestedTestAllTypes.getDefaultInstance())
           .out(intOf(0)),
       new TestCase(InterpreterTestCase.parse_repeat_index)
           .expr(
@@ -762,10 +742,8 @@ class InterpreterTest {
                   .setConstExpr(Constant.newBuilder().setStringValue("oneof_test"))
                   .build()),
       new TestCase(InterpreterTestCase.literal_pb_enum)
-          .container("google.api.expr.test.v1.proto3")
-          .types(
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes
-                  .getDefaultInstance())
+          .container("cel.expr.conformance.proto3")
+          .types(dev.cel.expr.conformance.proto3.TestAllTypes.getDefaultInstance())
           .expr(
               "TestAllTypes{\n"
                   + "repeated_nested_enum: [\n"
@@ -777,16 +755,13 @@ class InterpreterTest {
                   + "	TestAllTypes.NestedEnum.BAZ]}")
           .cost(costOf(0, 0))
           .out(
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes.newBuilder()
+              dev.cel.expr.conformance.proto3.TestAllTypes.newBuilder()
                   .addRepeatedNestedEnum(
-                      com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes.NestedEnum
-                          .FOO)
+                      dev.cel.expr.conformance.proto3.TestAllTypes.NestedEnum.FOO)
                   .addRepeatedNestedEnum(
-                      com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes.NestedEnum
-                          .BAZ)
+                      dev.cel.expr.conformance.proto3.TestAllTypes.NestedEnum.BAZ)
                   .addRepeatedNestedEnum(
-                      com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes.NestedEnum
-                          .BAR)
+                      dev.cel.expr.conformance.proto3.TestAllTypes.NestedEnum.BAR)
                   .addRepeatedInt32(0)
                   .addRepeatedInt32(2)
                   .build()),
@@ -849,21 +824,15 @@ class InterpreterTest {
           .cost(costOf(1, 4))
           .exhaustiveCost(costOf(4, 4)),
       new TestCase(InterpreterTestCase.macro_has_pb2_field)
-          .container("google.api.expr.test.v1.proto2")
-          .types(
-              com.google.api.expr.test.v1.proto2.TestAllTypesProto.TestAllTypes
-                  .getDefaultInstance())
-          .env(
-              Decls.newVar(
-                  "pb2", Decls.newObjectType("google.api.expr.test.v1.proto2.TestAllTypes")))
+          .container("cel.expr.conformance.proto2")
+          .types(dev.cel.expr.conformance.proto2.TestAllTypes.getDefaultInstance())
+          .env(Decls.newVar("pb2", Decls.newObjectType("cel.expr.conformance.proto2.TestAllTypes")))
           .in(
               "pb2",
-              com.google.api.expr.test.v1.proto2.TestAllTypesProto.TestAllTypes.newBuilder()
+              dev.cel.expr.conformance.proto2.TestAllTypes.newBuilder()
                   .addRepeatedBool(false)
                   .putMapInt64NestedType(
-                      1,
-                      com.google.api.expr.test.v1.proto2.TestAllTypesProto.NestedTestAllTypes
-                          .getDefaultInstance())
+                      1, dev.cel.expr.conformance.proto2.NestedTestAllTypes.getDefaultInstance())
                   .build())
           .expr(
               "has(TestAllTypes{standalone_enum: TestAllTypes.NestedEnum.BAR}.standalone_enum) \n"
@@ -879,21 +848,15 @@ class InterpreterTest {
           .cost(costOf(1, 29))
           .exhaustiveCost(costOf(29, 29)),
       new TestCase(InterpreterTestCase.macro_has_pb3_field)
-          .types(
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes
-                  .getDefaultInstance())
-          .env(
-              Decls.newVar(
-                  "pb3", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes")))
-          .container("google.api.expr.test.v1.proto3")
+          .types(dev.cel.expr.conformance.proto3.TestAllTypes.getDefaultInstance())
+          .env(Decls.newVar("pb3", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes")))
+          .container("cel.expr.conformance.proto3")
           .in(
               "pb3",
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes.newBuilder()
+              dev.cel.expr.conformance.proto3.TestAllTypes.newBuilder()
                   .addRepeatedBool(false)
                   .putMapInt64NestedType(
-                      1,
-                      com.google.api.expr.test.v1.proto3.TestAllTypesProto.NestedTestAllTypes
-                          .getDefaultInstance())
+                      1, dev.cel.expr.conformance.proto3.NestedTestAllTypes.getDefaultInstance())
                   .build())
           .expr(
               "has(TestAllTypes{standalone_enum: TestAllTypes.NestedEnum.BAR}.standalone_enum) \n"
@@ -927,18 +890,13 @@ class InterpreterTest {
       new TestCase(InterpreterTestCase.nested_proto_field)
           .expr("pb3.single_nested_message.bb")
           .cost(costOf(1, 1))
-          .types(
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes
-                  .getDefaultInstance())
-          .env(
-              Decls.newVar(
-                  "pb3", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes")))
+          .types(dev.cel.expr.conformance.proto3.TestAllTypes.getDefaultInstance())
+          .env(Decls.newVar("pb3", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes")))
           .in(
               "pb3",
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes.newBuilder()
+              dev.cel.expr.conformance.proto3.TestAllTypes.newBuilder()
                   .setSingleNestedMessage(
-                      com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes
-                          .NestedMessage.newBuilder()
+                      dev.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.newBuilder()
                           .setBb(1234)
                           .build())
                   .build())
@@ -946,25 +904,18 @@ class InterpreterTest {
       new TestCase(InterpreterTestCase.nested_proto_field_with_index)
           .expr("pb3.map_int64_nested_type[0].child.payload.single_int32 == 1")
           .cost(costOf(2, 2))
-          .types(
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes
-                  .getDefaultInstance())
-          .env(
-              Decls.newVar(
-                  "pb3", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes")))
+          .types(dev.cel.expr.conformance.proto3.TestAllTypes.getDefaultInstance())
+          .env(Decls.newVar("pb3", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes")))
           .in(
               "pb3",
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes.newBuilder()
+              dev.cel.expr.conformance.proto3.TestAllTypes.newBuilder()
                   .putMapInt64NestedType(
                       0,
-                      com.google.api.expr.test.v1.proto3.TestAllTypesProto.NestedTestAllTypes
-                          .newBuilder()
+                      dev.cel.expr.conformance.proto3.NestedTestAllTypes.newBuilder()
                           .setChild(
-                              com.google.api.expr.test.v1.proto3.TestAllTypesProto
-                                  .NestedTestAllTypes.newBuilder()
+                              dev.cel.expr.conformance.proto3.NestedTestAllTypes.newBuilder()
                                   .setPayload(
-                                      com.google.api.expr.test.v1.proto3.TestAllTypesProto
-                                          .TestAllTypes.newBuilder()
+                                      dev.cel.expr.conformance.proto3.TestAllTypes.newBuilder()
                                           .setSingleInt32(1)))
                           .build())
                   .build()),
@@ -1144,23 +1095,19 @@ class InterpreterTest {
                   + "&& json.list[0] == 'world'")
           .cost(costOf(1, 7))
           .exhaustiveCost(costOf(7, 7))
-          .container("google.api.expr.test.v1.proto3")
-          .types(
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes
-                  .getDefaultInstance())
+          .container("cel.expr.conformance.proto3")
+          .types(dev.cel.expr.conformance.proto3.TestAllTypes.getDefaultInstance())
           .env(
               Decls.newVar("a.b", Decls.newMapType(Decls.String, Decls.Bool)),
-              Decls.newVar(
-                  "pb3", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes")),
+              Decls.newVar("pb3", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes")),
               Decls.newVar("json", Decls.newMapType(Decls.String, Decls.Dyn)))
           .in(
               "a.b",
               mapOf("c", true),
               "pb3",
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes.newBuilder()
+              dev.cel.expr.conformance.proto3.TestAllTypes.newBuilder()
                   .addRepeatedNestedEnum(
-                      com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes.NestedEnum
-                          .BAR)
+                      dev.cel.expr.conformance.proto3.TestAllTypes.NestedEnum.BAR)
                   .build(),
               "json",
               Value.newBuilder()
@@ -1190,9 +1137,7 @@ class InterpreterTest {
           .exhaustiveCost(costOf(26, 26))
           .types(TestAllTypes.getDefaultInstance())
           .in("a", TestAllTypes.newBuilder().build())
-          .env(
-              Decls.newVar(
-                  "a", Decls.newObjectType("google.api.expr.test.v1.proto2.TestAllTypes"))),
+          .env(Decls.newVar("a", Decls.newObjectType("cel.expr.conformance.proto2.TestAllTypes"))),
       // Wrapper type nil or value test.
       new TestCase(InterpreterTestCase.select_pb3_wrapper_fields)
           .expr(
@@ -1202,69 +1147,53 @@ class InterpreterTest {
                   + "&& a.single_int64_wrapper == Int32Value{value: 0}")
           .cost(costOf(3, 21))
           .exhaustiveCost(costOf(21, 21))
-          .types(
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes
-                  .getDefaultInstance())
+          .types(dev.cel.expr.conformance.proto3.TestAllTypes.getDefaultInstance())
           .abbrevs("google.protobuf.Int32Value")
-          .env(
-              Decls.newVar("a", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes")))
+          .env(Decls.newVar("a", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes")))
           .in(
               "a",
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes.newBuilder()
+              dev.cel.expr.conformance.proto3.TestAllTypes.newBuilder()
                   .setSingleInt64Wrapper(Int64Value.newBuilder().build())
                   .setSingleStringWrapper(StringValue.of("hello"))
                   .build()),
       new TestCase(InterpreterTestCase.select_pb3_compare)
           .expr("a.single_uint64 > 3u")
           .cost(costOf(2, 2))
-          .container("google.api.expr.test.v1.proto3")
-          .types(
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes
-                  .getDefaultInstance())
-          .env(
-              Decls.newVar("a", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes")))
+          .container("cel.expr.conformance.proto3")
+          .types(dev.cel.expr.conformance.proto3.TestAllTypes.getDefaultInstance())
+          .env(Decls.newVar("a", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes")))
           .in(
               "a",
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes.newBuilder()
-                  .setSingleUint64(10)
-                  .build())
+              dev.cel.expr.conformance.proto3.TestAllTypes.newBuilder().setSingleUint64(10).build())
           .out(True),
       new TestCase(InterpreterTestCase.select_pb3_compare_signed)
           .expr("a.single_int64 > 3")
           .cost(costOf(2, 2))
-          .container("google.api.expr.test.v1.proto3")
-          .types(
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes
-                  .getDefaultInstance())
-          .env(
-              Decls.newVar("a", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes")))
+          .container("cel.expr.conformance.proto3")
+          .types(dev.cel.expr.conformance.proto3.TestAllTypes.getDefaultInstance())
+          .env(Decls.newVar("a", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes")))
           .in(
               "a",
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes.newBuilder()
-                  .setSingleInt64(10)
-                  .build())
+              dev.cel.expr.conformance.proto3.TestAllTypes.newBuilder().setSingleInt64(10).build())
           .out(True),
       new TestCase(InterpreterTestCase.select_custom_pb3_compare)
           .expr("a.bb > 100")
           .cost(costOf(2, 2))
-          .container("google.api.expr.test.v1.proto3")
-          .types(
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes.NestedMessage
-                  .getDefaultInstance())
+          .container("cel.expr.conformance.proto3")
+          .types(dev.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.getDefaultInstance())
           .env(
               Decls.newVar(
                   "a",
-                  Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes.NestedMessage")))
+                  Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes.NestedMessage")))
           .attrs(
               new CustAttrFactory(
                   newAttributeFactory(
-                      testContainer("google.api.expr.test.v1.proto3"),
+                      testContainer("cel.expr.conformance.proto3"),
                       DefaultTypeAdapter.Instance,
                       newEmptyRegistry())))
           .in(
               "a",
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes.NestedMessage
-                  .newBuilder()
+              dev.cel.expr.conformance.proto3.TestAllTypes.NestedMessage.newBuilder()
                   .setBb(101)
                   .build())
           .out(True),
@@ -1302,10 +1231,8 @@ class InterpreterTest {
       new TestCase(InterpreterTestCase.select_empty_repeated_nested)
           .expr("TestAllTypes{}.repeated_nested_message.size() == 0")
           .cost(costOf(2, 2))
-          .types(
-              com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes
-                  .getDefaultInstance())
-          .container("google.api.expr.test.v1.proto3")
+          .types(dev.cel.expr.conformance.proto3.TestAllTypes.getDefaultInstance())
+          .container("cel.expr.conformance.proto3")
           .out(True),
       new TestCase(InterpreterTestCase.duration_get_milliseconds)
           .expr("x.getMilliseconds()")
@@ -1423,25 +1350,21 @@ class InterpreterTest {
         program(
             new TestCase(InterpreterTestCase.nested_proto_field_with_index)
                 .expr("pb3.map_int64_nested_type[0].child.payload.single_int32")
-                .types(
-                    com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes
-                        .getDefaultInstance())
+                .types(dev.cel.expr.conformance.proto3.TestAllTypes.getDefaultInstance())
                 .env(
                     Decls.newVar(
-                        "pb3", Decls.newObjectType("google.api.expr.test.v1.proto3.TestAllTypes")))
+                        "pb3", Decls.newObjectType("cel.expr.conformance.proto3.TestAllTypes")))
                 .in(
                     "pb3",
-                    com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes.newBuilder()
+                    dev.cel.expr.conformance.proto3.TestAllTypes.newBuilder()
                         .putMapInt64NestedType(
                             0,
-                            com.google.api.expr.test.v1.proto3.TestAllTypesProto.NestedTestAllTypes
-                                .newBuilder()
+                            dev.cel.expr.conformance.proto3.NestedTestAllTypes.newBuilder()
                                 .setChild(
-                                    com.google.api.expr.test.v1.proto3.TestAllTypesProto
-                                        .NestedTestAllTypes.newBuilder()
+                                    dev.cel.expr.conformance.proto3.NestedTestAllTypes.newBuilder()
                                         .setPayload(
-                                            com.google.api.expr.test.v1.proto3.TestAllTypesProto
-                                                .TestAllTypes.newBuilder()
+                                            dev.cel.expr.conformance.proto3.TestAllTypes
+                                                .newBuilder()
                                                 .setSingleInt32(1)))
                                 .build())
                         .build()),
@@ -1608,15 +1531,14 @@ class InterpreterTest {
     ParseResult parsed = Parser.parseAllMacros(src);
     assertThat(parsed.hasErrors()).withFailMessage(parsed.getErrors()::toDisplayString).isFalse();
 
-    Container cont = testContainer("google.api.expr.test.v1.proto2");
+    Container cont = testContainer("cel.expr.conformance.proto2");
     TypeRegistry reg =
-        newRegistry(
-            com.google.api.expr.test.v1.proto2.TestAllTypesProto.TestAllTypes.getDefaultInstance());
+        newRegistry(dev.cel.expr.conformance.proto2.TestAllTypes.getDefaultInstance());
     CheckerEnv env = newStandardCheckerEnv(cont, reg);
     env.add(
         singletonList(
             Decls.newVar(
-                "input", Decls.newObjectType("google.api.expr.test.v1.proto2.TestAllTypes"))));
+                "input", Decls.newObjectType("cel.expr.conformance.proto2.TestAllTypes"))));
     CheckResult checkResult = Checker.Check(parsed, src, env);
     if (parsed.hasErrors()) {
       throw new IllegalArgumentException(parsed.getErrors().toDisplayString());
@@ -1633,8 +1555,8 @@ class InterpreterTest {
     double six = -2.2d;
     String str = "hello world";
     boolean truth = true;
-    com.google.api.expr.test.v1.proto2.TestAllTypesProto.TestAllTypes input =
-        com.google.api.expr.test.v1.proto2.TestAllTypesProto.TestAllTypes.newBuilder()
+    dev.cel.expr.conformance.proto2.TestAllTypes input =
+        dev.cel.expr.conformance.proto2.TestAllTypes.newBuilder()
             .setSingleInt32(one)
             .setSingleInt64(two)
             .setSingleUint32(three)

--- a/generated-pb/build.gradle.kts
+++ b/generated-pb/build.gradle.kts
@@ -49,11 +49,11 @@ val syncTestFixturesProtoSources =
   tasks.register<Sync>("syncTestFixturesProtoSources") {
     into(syncedTestFixturesProtoDir)
     from(layout.projectDirectory.dir("src/testFixtures/proto")) { include("*.proto") }
-    from(layout.settingsDirectory.dir("submodules/cel-spec/proto/test/v1/proto2")) {
-      into("proto/test/v1/proto2")
+    from(layout.settingsDirectory.dir("submodules/cel-spec/proto/cel/expr/conformance/proto2")) {
+      into("cel/expr/conformance/proto2")
     }
-    from(layout.settingsDirectory.dir("submodules/cel-spec/proto/test/v1/proto3")) {
-      into("proto/test/v1/proto3")
+    from(layout.settingsDirectory.dir("submodules/cel-spec/proto/cel/expr/conformance/proto3")) {
+      into("cel/expr/conformance/proto3")
     }
   }
 

--- a/generated-pb3/build.gradle.kts
+++ b/generated-pb3/build.gradle.kts
@@ -49,11 +49,11 @@ val syncTestFixturesProtoSources =
   tasks.register<Sync>("syncTestFixturesProtoSources") {
     into(syncedTestFixturesProtoDir)
     from(layout.settingsDirectory.dir("generated-pb/src/testFixtures/proto")) { include("*.proto") }
-    from(layout.settingsDirectory.dir("submodules/cel-spec/proto/test/v1/proto2")) {
-      into("proto/test/v1/proto2")
+    from(layout.settingsDirectory.dir("submodules/cel-spec/proto/cel/expr/conformance/proto2")) {
+      into("cel/expr/conformance/proto2")
     }
-    from(layout.settingsDirectory.dir("submodules/cel-spec/proto/test/v1/proto3")) {
-      into("proto/test/v1/proto3")
+    from(layout.settingsDirectory.dir("submodules/cel-spec/proto/cel/expr/conformance/proto3")) {
+      into("cel/expr/conformance/proto3")
     }
   }
 

--- a/quarkus-smoke-core-pb3-jackson3/src/main/java/org/projectnessie/cel/quarkus/smoke/corepb3jackson3/SmokeResource.java
+++ b/quarkus-smoke-core-pb3-jackson3/src/main/java/org/projectnessie/cel/quarkus/smoke/corepb3jackson3/SmokeResource.java
@@ -22,8 +22,9 @@ import static org.projectnessie.cel.EnvOption.declarations;
 import static org.projectnessie.cel.EnvOption.types;
 import static org.projectnessie.cel.Library.StdLib;
 
-import com.google.api.expr.test.v1.proto3.TestAllTypesProto.TestAllTypes;
 import com.google.protobuf.Int32Value;
+import dev.cel.expr.conformance.proto3.NestedTestAllTypes;
+import dev.cel.expr.conformance.proto3.TestAllTypes;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -123,7 +124,7 @@ public class SmokeResource {
 
   public record SmokeResponse(String engine, boolean jackson, boolean protobuf) {}
 
-  @RegisterForReflection(targets = TestAllTypes.class)
+  @RegisterForReflection(targets = {TestAllTypes.class, NestedTestAllTypes.class})
   static final class ProtobufReflection {}
 
   @RegisterForReflection


### PR DESCRIPTION
This change adds the necessary base work for the CEL-Spec bump.

Follow-up PRs will make the code-base fully aligned with the new spec version.

The previously used conformance-tests approach to use Google's "simple conformance test runner" no longer works, because that simple-runner has been removed. This change keeps the gRPC client/server architecture for conformance tests. A follow-up PR will remove the gRPC bridge entirely.